### PR TITLE
chore: bump version to v1.81.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.81.0"
+version = "1.81.1"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"


### PR DESCRIPTION
## Summary
- Bump version to v1.81.1 for crates.io publish from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)