### PR TITLE
fix: exclude .DS_Store from cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 readme = "README.md"
 include = [
-    "/src/**/*",
+    "/src/**/*.rs",
     "/examples/**/*",
     "/hooks/**/*",
     "/templates/**/*",
@@ -27,6 +27,7 @@ include = [
     "/CHANGELOG.md",
     "/CONTRIBUTING.md",
 ]
+exclude = [".DS_Store"]
 
 [[bin]]
 name = "airis"


### PR DESCRIPTION
## Summary
- `/src/**/*` → `/src/**/*.rs` で .DS_Store をパッケージから除外
- `cargo publish --verify` が .DS_Store で失敗する問題を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)