### PR TITLE
fix(security): block shell injection in extra_args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "1.81.1"
+version = "1.81.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.81.2"
+version = "1.82.0"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"
@@ -27,7 +27,6 @@ include = [
     "/CHANGELOG.md",
     "/CONTRIBUTING.md",
 ]
-exclude = [".DS_Store"]
 
 [[bin]]
 name = "airis"

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1220,6 +1220,24 @@ fn has_orchestration(manifest: &Manifest) -> bool {
 
 /// Execute a command defined in manifest.toml [commands] section
 pub fn run(task: &str, extra_args: &[String]) -> Result<()> {
+    // Block shell metacharacters in extra_args to prevent host command injection
+    for arg in extra_args {
+        if arg.contains(';')
+            || arg.contains("&&")
+            || arg.contains("||")
+            || arg.contains('|')
+            || arg.contains('`')
+            || arg.contains("$(")
+        {
+            bail!(
+                "❌ Shell metacharacters are not allowed in extra arguments: {}\n\
+                 This restriction prevents host command injection.\n\
+                 If you need complex commands, define them in manifest.toml [commands].",
+                arg.bold()
+            );
+        }
+    }
+
     let manifest_path = Path::new("manifest.toml");
 
     // Allow up/down without manifest.toml if compose file exists
@@ -1303,7 +1321,7 @@ pub fn run(task: &str, extra_args: &[String]) -> Result<()> {
         ensure_env_file();
     }
 
-    // Append extra arguments if provided
+    // Append extra arguments if provided (metacharacter check already done above)
     let full_cmd = if extra_args.is_empty() {
         cmd.to_string()
     } else {
@@ -2448,5 +2466,117 @@ post_up = [
             manifest.dev.post_up[1],
             "docker compose exec workspace pnpm db:seed"
         );
+    }
+
+    #[test]
+    fn test_extra_args_blocks_shell_injection_semicolon() {
+        let _guard = DIR_LOCK.lock().unwrap();
+        let dir = tempdir().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+
+        // Create a minimal manifest.toml
+        std::fs::write(
+            "manifest.toml",
+            r#"
+version = 1
+[workspace]
+name = "test"
+package_manager = "pnpm"
+service = "workspace"
+image = "node:22"
+[commands]
+test = "echo safe"
+"#,
+        )
+        .unwrap();
+
+        let result = std::panic::catch_unwind(|| {
+            let result = run("test", &["; rm -rf /".to_string()]);
+            assert!(result.is_err());
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("Shell metacharacters"),
+                "Expected shell metacharacter error, got: {}",
+                err
+            );
+        });
+
+        std::env::set_current_dir(original_dir).unwrap();
+        result.unwrap();
+    }
+
+    #[test]
+    fn test_extra_args_blocks_shell_injection_pipe() {
+        let _guard = DIR_LOCK.lock().unwrap();
+        let dir = tempdir().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+
+        std::fs::write(
+            "manifest.toml",
+            r#"
+version = 1
+[workspace]
+name = "test"
+package_manager = "pnpm"
+service = "workspace"
+image = "node:22"
+[commands]
+test = "echo safe"
+"#,
+        )
+        .unwrap();
+
+        let result = std::panic::catch_unwind(|| {
+            let result = run("test", &["| cat /etc/passwd".to_string()]);
+            assert!(result.is_err());
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("Shell metacharacters"),
+                "Expected shell metacharacter error, got: {}",
+                err
+            );
+        });
+
+        std::env::set_current_dir(original_dir).unwrap();
+        result.unwrap();
+    }
+
+    #[test]
+    fn test_extra_args_blocks_command_substitution() {
+        let _guard = DIR_LOCK.lock().unwrap();
+        let dir = tempdir().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+
+        std::fs::write(
+            "manifest.toml",
+            r#"
+version = 1
+[workspace]
+name = "test"
+package_manager = "pnpm"
+service = "workspace"
+image = "node:22"
+[commands]
+test = "echo safe"
+"#,
+        )
+        .unwrap();
+
+        let result = std::panic::catch_unwind(|| {
+            let result = run("test", &["$(whoami)".to_string()]);
+            assert!(result.is_err());
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("Shell metacharacters"),
+                "Expected shell metacharacter error, got: {}",
+                err
+            );
+        });
+
+        std::env::set_current_dir(original_dir).unwrap();
+        result.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- `extra_args` にシェルメタ文字（`;`, `&&`, `||`, `|`, `` ` ``, `$(`)が含まれていたら即座に拒否
- チェックは `run()` 関数冒頭で manifest 読み込み前に実行
- `airis test -- "; pnpm install"` のようなインジェクションをブロック
- `airis test -- --grep mytest` のような正当な引数は通す
- テスト3件追加（semicolon, pipe, command substitution）
- `Cargo.toml` の不要な `exclude` 削除

## Test plan
- [x] `cargo test shell_injection` — 3テスト通過
- [x] `cargo test command_substitution` — 通過
- [x] `cargo test` — 192/193 通過（1件は既存の flaky テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)