### PR TITLE
fix(build): Windows cross-compilation and CI warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "1.91.0"
+version = "1.92.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.92.0"
+version = "1.93.0"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/guards.rs
+++ b/src/commands/guards.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::io::BufRead;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
@@ -158,9 +159,12 @@ exec {} "$@"
 }
 
 fn make_executable(path: &Path) -> Result<()> {
-    let mut perms = fs::metadata(path)?.permissions();
-    perms.set_mode(0o755); // rwxr-xr-x
-    fs::set_permissions(path, perms)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755); // rwxr-xr-x
+        fs::set_permissions(path, perms)?;
+    }
     Ok(())
 }
 

--- a/src/commands/shim.rs
+++ b/src/commands/shim.rs
@@ -5,6 +5,7 @@
 
 use std::env;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -150,9 +151,12 @@ fi
     fs::write(path, script)?;
 
     // Make executable
-    let mut perms = fs::metadata(path)?.permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
 
     Ok(())
 }
@@ -168,9 +172,12 @@ exec "$DIR/_shim" "$@"
     fs::write(path, script)?;
 
     // Make executable
-    let mut perms = fs::metadata(path)?.permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
 
     Ok(())
 }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -7,6 +7,7 @@ use colored::Colorize;
 use serde::Deserialize;
 use std::env;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -133,9 +134,12 @@ pub fn run(target_version: Option<String>) -> Result<()> {
     };
 
     // Make executable
-    let mut perms = fs::metadata(&binary_path)?.permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(&binary_path, perms)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(&binary_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&binary_path, perms)?;
+    }
 
     // Verify binary works
     println!("Verifying...");


### PR DESCRIPTION
## Summary
- Gate `PermissionsExt::set_mode()` with `#[cfg(unix)]` in shim.rs, upgrade.rs, guards.rs — fixes Windows build failure
- Fix duplicate `#[test]` attribute and deprecated `cargo_bin` warning — fixes `-D warnings` CI failure

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test` passes locally
- [ ] CI passes on all platforms (macOS, Linux, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)