### PR TITLE
fix(build): complete Windows cross-compilation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "1.92.0"
+version = "1.93.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.93.0"
+version = "1.94.0"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/guards.rs
+++ b/src/commands/guards.rs
@@ -158,12 +158,12 @@ exec {} "$@"
     Ok(())
 }
 
-fn make_executable(path: &Path) -> Result<()> {
+fn make_executable(_path: &Path) -> Result<()> {
     #[cfg(unix)]
     {
-        let mut perms = fs::metadata(path)?.permissions();
+        let mut perms = fs::metadata(_path)?.permissions();
         perms.set_mode(0o755); // rwxr-xr-x
-        fs::set_permissions(path, perms)?;
+        fs::set_permissions(_path, perms)?;
     }
     Ok(())
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,4 +1,5 @@
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::symlink;
 use std::path::Path;
 
@@ -178,6 +179,12 @@ fn run_template_mode(write: bool) -> Result<()> {
 
 /// Setup .npmrc symlinks for Docker-First enforcement
 /// This creates symlinks in apps/* and libs/* pointing to root .npmrc
+#[cfg(not(unix))]
+pub fn setup_npmrc() -> Result<()> {
+    anyhow::bail!("setup-npmrc requires Unix (symlink support)");
+}
+
+#[cfg(unix)]
 pub fn setup_npmrc() -> Result<()> {
     println!("{}", "🔗 Setting up .npmrc symlinks...".bright_blue());
     println!();


### PR DESCRIPTION
## Summary
- Gate `symlink` import and `setup_npmrc()` in init.rs with `#[cfg(unix)]`
- Fix unused variable warning in guards.rs `make_executable` on Windows

Follows up on PR #82 which missed init.rs symlink usage.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test` passes locally
- [ ] CI passes (macOS test)
- [ ] Release workflow builds all 5 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)