### PR TITLE
fix(release): macos-13 runner deprecation and Windows warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             os: macos
             archive: tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             os: macos
             archive: tar.gz
           - target: x86_64-unknown-linux-gnu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "1.93.0"
+version = "1.94.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.94.0"
+version = "1.95.0"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -4,6 +4,7 @@ use std::os::unix::fs::symlink;
 use std::path::Path;
 
 use anyhow::Result;
+#[cfg(unix)]
 use chrono::Local;
 use colored::Colorize;
 
@@ -14,6 +15,7 @@ use super::migrate;
 
 /// Create a backup of a file before replacing it
 /// Returns the backup path if successful
+#[cfg(unix)]
 fn backup_file(path: &Path) -> Result<std::path::PathBuf> {
     let timestamp = Local::now().format("%Y%m%d_%H%M%S");
     let backup_name = format!(


### PR DESCRIPTION
## Summary
- Replace deprecated `macos-13` runner with `macos-latest` for x86_64-apple-darwin builds
- Gate `backup_file` and `chrono::Local` with `#[cfg(unix)]` to fix Windows `-D warnings`

Previous release failed because macos-13 is no longer available on GitHub Actions.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test` passes locally
- [ ] Release workflow completes on all 5 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)