### PR TITLE
fix(release): cargo publish --allow-dirty for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,4 +189,4 @@ jobs:
         if: steps.check_tag.outputs.exists == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --no-verify
+        run: cargo publish --no-verify --allow-dirty


### PR DESCRIPTION
## Summary
- Add `--allow-dirty` to `cargo publish` in release workflow
- Downloaded artifacts (tar.gz, zip, SHA256SUMS.txt) cause dirty working directory detection

## Test plan
- [ ] Release workflow completes including cargo publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)