### PR TITLE
feat: auto-resolve GitHub Actions versions from latest tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "1.119.0"
+version = "1.120.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.120.0"
+version = "1.121.0"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1436,41 +1436,37 @@ impl Default for CiSection {
     }
 }
 
-fn default_action_version() -> String {
-    "v6".to_string()
-}
-
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ActionsVersions {
     /// actions/checkout version. Default: "v6"
-    #[serde(default = "default_action_version")]
+    #[serde(default = "default_v6")]
     pub checkout: String,
-    /// pnpm/action-setup version. Default: "v6"
-    #[serde(default = "default_action_version")]
+    /// pnpm/action-setup version. Default: "v5"
+    #[serde(default = "default_v5")]
     pub pnpm: String,
     /// actions/setup-node version. Default: "v6"
-    #[serde(default = "default_action_version")]
+    #[serde(default = "default_v6")]
     pub setup_node: String,
-    /// actions/cache version. Default: "v6"
-    #[serde(default = "default_action_version")]
+    /// actions/cache version. Default: "v5"
+    #[serde(default = "default_v5")]
     pub cache: String,
     /// dopplerhq/cli-action version. Default: "v3"
-    #[serde(default = "default_doppler_version")]
+    #[serde(default = "default_v3")]
     pub doppler: String,
 }
 
-fn default_doppler_version() -> String {
-    "v3".to_string()
-}
+fn default_v6() -> String { "v6".to_string() }
+fn default_v5() -> String { "v5".to_string() }
+fn default_v3() -> String { "v3".to_string() }
 
 impl Default for ActionsVersions {
     fn default() -> Self {
         ActionsVersions {
-            checkout: default_action_version(),
-            pnpm: default_action_version(),
-            setup_node: default_action_version(),
-            cache: default_action_version(),
-            doppler: default_doppler_version(),
+            checkout: default_v6(),
+            pnpm: default_v5(),
+            setup_node: default_v6(),
+            cache: default_v5(),
+            doppler: default_v3(),
         }
     }
 }

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -2,10 +2,30 @@ use anyhow::{Context, Result};
 use handlebars::Handlebars;
 use indexmap::IndexMap;
 use serde_json::json;
-use crate::version_resolver::resolve_version;
-use crate::manifest::{MANIFEST_FILE, Manifest};
+use crate::version_resolver::{resolve_version, resolve_all_action_versions};
+use crate::manifest::{ActionsVersions, MANIFEST_FILE, Manifest};
 
-// No hardcoded action versions — all driven by manifest.toml [ci.actions]
+/// Resolved GitHub Actions versions with full action references (e.g., "actions/checkout@v6")
+struct ResolvedActions {
+    checkout: String,
+    pnpm: String,
+    setup_node: String,
+    cache: String,
+    doppler: String,
+}
+
+impl ResolvedActions {
+    fn from_manifest(actions: &ActionsVersions) -> Result<Self> {
+        let resolved = resolve_all_action_versions(actions)?;
+        Ok(ResolvedActions {
+            checkout: format!("actions/checkout@{}", resolved.checkout),
+            pnpm: format!("pnpm/action-setup@{}", resolved.pnpm),
+            setup_node: format!("actions/setup-node@{}", resolved.setup_node),
+            cache: format!("actions/cache@{}", resolved.cache),
+            doppler: format!("dopplerhq/cli-action@{}", resolved.doppler),
+        })
+    }
+}
 
 /// Resolve dependency versions by expanding catalog references and version policies
 ///
@@ -308,11 +328,10 @@ impl TemplateEngine {
         }
 
         let ci = &manifest.ci;
-        let actions = &ci.actions;
-        let checkout = format!("actions/checkout@{}", actions.checkout);
-        let pnpm_action = format!("pnpm/action-setup@{}", actions.pnpm);
-        let setup_node = format!("actions/setup-node@{}", actions.setup_node);
-        let cache_action = format!("actions/cache@{}", actions.cache);
+        let a = ResolvedActions::from_manifest(&ci.actions)?;
+        let checkout = &a.checkout;
+        let pnpm_action = &a.pnpm;
+        let setup_node = &a.setup_node;
         let node_version = manifest.node_version();
         let runner = ci.runner.as_deref().unwrap_or("ubuntu-latest");
         let affected_flag = if ci.affected { " --affected" } else { "" };
@@ -331,7 +350,7 @@ impl TemplateEngine {
                 store_path
             )
         } else {
-            format!("      - name: Cache pnpm store\n        uses: {}\n        with:\n          path: ~/.pnpm-store\n          key: ${{{{ runner.os }}}}-pnpm-${{{{ hashFiles('pnpm-lock.yaml') }}}}\n          restore-keys: ${{{{ runner.os }}}}-pnpm-", cache_action)
+            format!("      - name: Cache pnpm store\n        uses: {}\n        with:\n          path: ~/.pnpm-store\n          key: ${{{{ runner.os }}}}-pnpm-${{{{ hashFiles('pnpm-lock.yaml') }}}}\n          restore-keys: ${{{{ runner.os }}}}-pnpm-", a.cache)
         };
 
         // Determine CI branch and PR target from profiles
@@ -375,7 +394,8 @@ impl TemplateEngine {
     /// Generate CI workflow for infrastructure-only repos (no Node.js)
     fn render_infra_ci_workflow(&self, manifest: &Manifest) -> Result<String> {
         let ci = &manifest.ci;
-        let checkout = format!("actions/checkout@{}", ci.actions.checkout);
+        let a = ResolvedActions::from_manifest(&ci.actions)?;
+        let checkout = &a.checkout;
         let runner = ci.runner.as_deref().unwrap_or("ubuntu-latest");
         let runner_yaml = if runner.contains(',') {
             format!("[{}]", runner)
@@ -398,12 +418,11 @@ impl TemplateEngine {
     /// Generate .github/workflows/deploy.yml from manifest v2
     pub fn render_deploy_workflow(&self, manifest: &Manifest) -> Result<String> {
         let ci = &manifest.ci;
-        let actions = &ci.actions;
-        let checkout = format!("actions/checkout@{}", actions.checkout);
-        let pnpm_action = format!("pnpm/action-setup@{}", actions.pnpm);
-        let setup_node = format!("actions/setup-node@{}", actions.setup_node);
-        let cache_action = format!("actions/cache@{}", actions.cache);
-        let doppler_action = format!("dopplerhq/cli-action@{}", actions.doppler);
+        let a = ResolvedActions::from_manifest(&ci.actions)?;
+        let checkout = &a.checkout;
+        let pnpm_action = &a.pnpm;
+        let setup_node = &a.setup_node;
+        let doppler_action = &a.doppler;
         let node_version = manifest.node_version();
         let runner = ci.runner.as_deref().unwrap_or("ubuntu-latest");
         let worker_runner = ci.worker_runner.as_deref().unwrap_or("ubuntu-latest");
@@ -564,7 +583,7 @@ impl TemplateEngine {
                 store_path
             )
         } else {
-            format!("      - name: Cache pnpm store\n        uses: {}\n        with:\n          path: ~/.pnpm-store\n          key: ${{{{ runner.os }}}}-pnpm-${{{{ hashFiles('pnpm-lock.yaml') }}}}\n          restore-keys: ${{{{ runner.os }}}}-pnpm-", cache_action)
+            format!("      - name: Cache pnpm store\n        uses: {}\n        with:\n          path: ~/.pnpm-store\n          key: ${{{{ runner.os }}}}-pnpm-${{{{ hashFiles('pnpm-lock.yaml') }}}}\n          restore-keys: ${{{{ runner.os }}}}-pnpm-", a.cache)
         };
 
         let mut worker_jobs = Vec::new();
@@ -614,8 +633,9 @@ impl TemplateEngine {
     /// Generate deploy workflow for infrastructure-only repos (no apps)
     fn render_infra_deploy_workflow(&self, manifest: &Manifest) -> Result<String> {
         let ci = &manifest.ci;
-        let checkout = format!("actions/checkout@{}", ci.actions.checkout);
-        let doppler_action = format!("dopplerhq/cli-action@{}", ci.actions.doppler);
+        let a = ResolvedActions::from_manifest(&ci.actions)?;
+        let checkout = &a.checkout;
+        let doppler_action = &a.doppler;
         let runner = ci.runner.as_deref().unwrap_or("ubuntu-latest");
         let runner_yaml = if runner.contains(',') {
             format!("[{}]", runner)

--- a/src/version_resolver.rs
+++ b/src/version_resolver.rs
@@ -90,6 +90,112 @@ pub fn get_npm_lts(package: &str) -> Result<String> {
     Ok(format!("^{version}"))
 }
 
+/// GitHub Actions version resolver
+///
+/// Maps action short names to their GitHub repos, then queries
+/// the GitHub API for the latest major version tag (e.g., "v6").
+const GITHUB_ACTIONS: &[(&str, &str)] = &[
+    ("checkout", "actions/checkout"),
+    ("pnpm", "pnpm/action-setup"),
+    ("setup_node", "actions/setup-node"),
+    ("cache", "actions/cache"),
+    ("doppler", "dopplerhq/cli-action"),
+];
+
+/// Resolve a GitHub Action version policy.
+///
+/// - "latest" → fetch latest major version tag from GitHub
+/// - "v5", "v6" etc. → pass through as-is
+pub fn resolve_action_version(action_key: &str, policy: &str) -> Result<String> {
+    if policy != "latest" {
+        return Ok(policy.to_string());
+    }
+
+    let repo = GITHUB_ACTIONS
+        .iter()
+        .find(|(k, _)| *k == action_key)
+        .map(|(_, r)| *r)
+        .context(format!("Unknown action key: {action_key}"))?;
+
+    get_github_latest_major_tag(repo)
+}
+
+/// Fetch the latest major version tag (e.g., "v6") from a GitHub repo.
+///
+/// Looks for tags matching `vN` (major-only), sorted descending.
+fn get_github_latest_major_tag(repo: &str) -> Result<String> {
+    let url = format!("https://api.github.com/repos/{repo}/tags?per_page=100");
+    let response = ureq::get(&url)
+        .set("Accept", "application/vnd.github+json")
+        .set("User-Agent", "airis-monorepo")
+        .call()
+        .context(format!("Failed to fetch tags for {repo}"))?;
+
+    let tags: Vec<serde_json::Value> = response
+        .into_json()
+        .context(format!("Failed to parse tags JSON for {repo}"))?;
+
+    // Find major-only tags (v1, v2, ..., v6) — these are the stable refs
+    let mut major_versions: Vec<u32> = tags
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+        .filter_map(|name| {
+            let stripped = name.strip_prefix('v')?;
+            // Only pure major tags like "v6", not "v6.0.0" or "v6-beta"
+            if stripped.chars().all(|c| c.is_ascii_digit()) {
+                stripped.parse::<u32>().ok()
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    major_versions.sort_unstable();
+    major_versions
+        .last()
+        .map(|v| format!("v{v}"))
+        .context(format!("No major version tags found for {repo}"))
+}
+
+/// Resolve all action versions in an ActionsVersions struct.
+///
+/// Any field set to "latest" will be resolved to the actual latest major tag.
+/// Progress is printed to stderr for user feedback.
+pub fn resolve_all_action_versions(
+    actions: &crate::manifest::ActionsVersions,
+) -> Result<crate::manifest::ActionsVersions> {
+    let fields = [
+        ("checkout", &actions.checkout),
+        ("pnpm", &actions.pnpm),
+        ("setup_node", &actions.setup_node),
+        ("cache", &actions.cache),
+        ("doppler", &actions.doppler),
+    ];
+
+    let mut resolved = actions.clone();
+    for (key, value) in &fields {
+        if *value == "latest" {
+            let repo = GITHUB_ACTIONS
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, r)| *r)
+                .unwrap();
+            let version = resolve_action_version(key, value)?;
+            eprintln!("  ✓ {} ({}) latest → {}", key, repo, version);
+            match *key {
+                "checkout" => resolved.checkout = version,
+                "pnpm" => resolved.pnpm = version,
+                "setup_node" => resolved.setup_node = version,
+                "cache" => resolved.cache = version,
+                "doppler" => resolved.doppler = version,
+                _ => {}
+            }
+        }
+    }
+
+    Ok(resolved)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

`[ci.actions]` に `"latest"` ポリシーを追加。`airis gen` 時に GitHub API から最新メジャーバージョンタグ（v5, v6 等）を自動解決する。npm catalog の `"latest"` と同じパターン。

- テンプレートのハードコードされたアクションバージョンを全て除去
- `ResolvedActions` struct でアクション参照を一元管理
- pnpm/action-setup のデフォルトを v5 に修正（v6 は存在しない）

## Test plan
- [x] `cargo build` — 0 warnings
- [x] `cargo test` — 249 tests passed


🤖 Generated with [Claude Code](https://claude.com/claude-code)