### PR TITLE
docs: update CLI help to match AI-native vision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "1.120.0"
+version = "1.121.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.121.0"
+version = "1.122.0"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,21 +90,20 @@ fn convert_package_to_path(package_name: &str) -> String {
 
 #[derive(Parser)]
 #[command(name = "airis")]
-#[command(about = "Docker-first monorepo workspace manager")]
+#[command(about = "The Docker-first monorepo manager for the vibe coding era")]
 #[command(long_about = "\
-Docker-first monorepo workspace manager.
+The Docker-first monorepo manager for the vibe coding era.
 
-airis generates package.json, docker-compose.yml, pnpm-workspace.yaml, and CI \
-workflows from a single manifest.toml. It guards your host from AI agents running \
-package managers directly.
+One manifest file. Every config generated. Your AI pair-programmer stays inside \
+the container where it belongs.
 
-DESIGN: airis is project-agnostic. It wraps whatever commands YOU define in \
-manifest.toml [commands]. Environment management (Doppler, .env, Infisical), \
-deploy targets (Vercel, Railway, Fly.io), and build tools (Turborepo, NX) are \
-all your choice — airis doesn't impose any of them.
+airis generates Dockerfile, compose.yml, package.json, pnpm-workspace.yaml, and \
+CI/CD workflows from a single manifest.toml. Command guards keep AI agents from \
+running package managers on the host or picking the wrong tool.
 
-IMPORTANT: manifest.toml is optional. Without it, each app works standalone \
-with `docker compose up`. airis adds convenience, not dependency.")]
+DESIGN: airis extends your existing stack — it doesn't replace it. Turborepo, NX, \
+Doppler, Vercel, Railway — all your choice. airis handles the Docker layer that \
+those tools leave to you.")]
 #[command(after_help = "\
 QUICK REFERENCE:
   airis init --write        Create manifest.toml from project discovery

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -25,7 +25,7 @@ fn test_help_flag() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Docker-first monorepo workspace manager"));
+        .stdout(predicate::str::contains("Docker-first monorepo manager for the vibe coding era"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

CLI の `--help` を README の新しいビジョンに合わせて更新。

- about: "The Docker-first monorepo manager for the vibe coding era"
- "extends your existing stack, doesn't replace it" の思想を反映
- テストも更新済み


🤖 Generated with [Claude Code](https://claude.com/claude-code)