### PR TITLE
feat: declarative pre-command hooks with cache-based skip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "1.127.0"
+version = "1.128.0"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1359,6 +1359,11 @@ pub fn run(task: &str, extra_args: &[String]) -> Result<()> {
         ensure_env_file();
     }
 
+    // Run pre-command hook if configured
+    if !manifest.hooks.skip.contains(&task.to_string()) {
+        ensure_pre_command(&manifest)?;
+    }
+
     // Append extra arguments if provided (metacharacter check already done above)
     let full_cmd = if extra_args.is_empty() {
         cmd.to_string()
@@ -1812,6 +1817,103 @@ pub fn run_test_coverage(min_coverage: u8) -> Result<()> {
     }
 
     Ok(())
+}
+
+// ── Pre-command hooks ─────────────────────────────────────
+
+/// Run the pre_command hook if configured and cache key has changed.
+fn ensure_pre_command(manifest: &Manifest) -> Result<()> {
+    let pre_command = match &manifest.hooks.pre_command {
+        Some(cmd) => cmd,
+        None => return Ok(()),
+    };
+
+    // Cache check: skip if key file unchanged
+    if let Some(cache) = &manifest.hooks.cache {
+        let key_path = Path::new(&cache.key);
+        if key_path.exists() {
+            let current_hash = sha256_file(key_path)?;
+            let hash_file = Path::new(".airis/hook-cache");
+            if let Ok(saved) = std::fs::read_to_string(hash_file) {
+                if saved.trim() == current_hash {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    println!("{}", format!("📦 Running pre-command: {}", pre_command).bright_blue());
+
+    let success = execute_hook_command(pre_command, manifest)?;
+
+    if success {
+        // Save hash after successful execution
+        if let Some(cache) = &manifest.hooks.cache {
+            let key_path = Path::new(&cache.key);
+            if key_path.exists() {
+                let hash = sha256_file(key_path)?;
+                std::fs::create_dir_all(".airis")
+                    .context("Failed to create .airis directory")?;
+                std::fs::write(".airis/hook-cache", &hash)
+                    .context("Failed to write hook cache")?;
+            }
+        }
+        println!("{}", "  ✓ Pre-command completed".green());
+    } else {
+        println!("{}", "  ⚠ Pre-command failed (continuing anyway)".yellow());
+    }
+
+    Ok(())
+}
+
+/// Compute SHA256 hash of a file.
+fn sha256_file(path: &Path) -> Result<String> {
+    use sha2::{Sha256, Digest};
+    let content = std::fs::read(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    Ok(format!("{:x}", Sha256::digest(&content)))
+}
+
+/// Execute a hook command respecting Docker-first mode.
+/// Docker-first: exec (running container) → run --rm (temporary container) fallback.
+/// Non-Docker: direct shell execution.
+fn execute_hook_command(cmd: &str, manifest: &Manifest) -> Result<bool> {
+    let is_docker_first = matches!(manifest.mode, crate::manifest::Mode::DockerFirst);
+
+    if is_docker_first {
+        let svc = manifest.docker.workspace
+            .as_ref()
+            .map(|w| w.service.as_str())
+            .filter(|s| !s.is_empty())
+            .or_else(|| manifest.service.keys().next().map(|s| s.as_str()));
+
+        if let Some(svc) = svc {
+            // Try exec first (fast, uses running container)
+            let status = Command::new("docker")
+                .args(["compose", "exec", "-T", svc, "sh", "-c", cmd])
+                .status();
+
+            match status {
+                Ok(s) if s.success() => return Ok(true),
+                _ => {
+                    // Fallback: run --rm (starts temporary container)
+                    println!("  {} container not running, starting temporary container...", "↻".yellow());
+                    let status = Command::new("docker")
+                        .args(["compose", "run", "--rm", "--no-deps", "-T", svc, "sh", "-c", cmd])
+                        .status()
+                        .context("Failed to execute docker compose run")?;
+                    return Ok(status.success());
+                }
+            }
+        }
+    }
+
+    // Non-Docker: direct execution
+    let status = Command::new("sh")
+        .args(["-c", cmd])
+        .status()
+        .with_context(|| format!("Failed to execute hook: {}", cmd))?;
+    Ok(status.success())
 }
 
 #[cfg(test)]
@@ -2739,5 +2841,62 @@ test = "echo safe"
             networks: vec![],
         };
         assert_eq!(extract_host_port_from_service(&svc), None);
+    }
+
+    #[test]
+    fn test_sha256_file_deterministic() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, "hello world").unwrap();
+
+        let hash1 = sha256_file(&file).unwrap();
+        let hash2 = sha256_file(&file).unwrap();
+        assert_eq!(hash1, hash2);
+        // Known SHA256 of "hello world"
+        assert_eq!(hash1, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+    }
+
+    #[test]
+    fn test_sha256_file_changes_with_content() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+
+        std::fs::write(&file, "version 1").unwrap();
+        let hash1 = sha256_file(&file).unwrap();
+
+        std::fs::write(&file, "version 2").unwrap();
+        let hash2 = sha256_file(&file).unwrap();
+
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_pre_command_hooks_default_is_none() {
+        let hooks = crate::manifest::PreCommandHooks::default();
+        assert!(hooks.pre_command.is_none());
+        assert!(hooks.skip.is_empty());
+        assert!(hooks.cache.is_none());
+    }
+
+    #[test]
+    fn test_hooks_section_parses_from_toml() {
+        let toml_str = r#"
+[workspace]
+name = "test"
+
+[hooks]
+pre_command = "pnpm install"
+skip = ["up", "down", "ps"]
+
+[hooks.cache]
+key = "pnpm-lock.yaml"
+
+[versioning]
+strategy = "manual"
+"#;
+        let manifest: Manifest = toml::from_str(toml_str).unwrap();
+        assert_eq!(manifest.hooks.pre_command.as_deref(), Some("pnpm install"));
+        assert_eq!(manifest.hooks.skip, vec!["up", "down", "ps"]);
+        assert_eq!(manifest.hooks.cache.as_ref().unwrap().key, "pnpm-lock.yaml");
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -59,6 +59,9 @@ pub struct Manifest {
     pub app: Vec<ProjectDefinition>,
     #[serde(default)]
     pub orchestration: OrchestrationSection,
+    /// Pre-command hooks (e.g., auto-install before test/build)
+    #[serde(default)]
+    pub hooks: PreCommandHooks,
     /// User-defined commands (airis run <task>)
     #[serde(default)]
     pub commands: IndexMap<String, String>,
@@ -86,6 +89,9 @@ pub struct Manifest {
     /// Value injection into user-owned files via `# airis:inject <key>` markers
     #[serde(default)]
     pub inject: IndexMap<String, InjectValue>,
+    /// TypeScript configuration for tsconfig generation
+    #[serde(default)]
+    pub typescript: TypescriptSection,
 
     // ── v2 fields (ignored when version = 1) ──
 
@@ -435,6 +441,7 @@ impl Manifest {
                 cmds.insert("ps".to_string(), "docker compose ps".to_string());
                 cmds
             },
+            hooks: PreCommandHooks::default(),
             remap,
             versioning: VersioningSection {
                 strategy: VersioningStrategy::Manual,
@@ -446,6 +453,7 @@ impl Manifest {
             runtimes: RuntimesSection::default(),
             env: EnvSection::default(),
             inject: IndexMap::new(),
+            typescript: TypescriptSection::default(),
             profile: IndexMap::new(),
             preset: IndexMap::new(),
             external: IndexMap::new(),
@@ -783,6 +791,29 @@ pub struct RuleConfig {
     pub commands: Vec<String>,
 }
 
+/// Pre-command hooks configuration.
+/// Runs a command before each `airis run <task>` invocation.
+/// Cache key avoids re-running when dependencies haven't changed.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct PreCommandHooks {
+    /// Shell command to run before each airis command (e.g., "pnpm install")
+    #[serde(default)]
+    pub pre_command: Option<String>,
+    /// Commands that skip the pre_command hook (e.g., ["up", "down", "ps"])
+    #[serde(default)]
+    pub skip: Vec<String>,
+    /// Cache config: only run hook when key file changes
+    #[serde(default)]
+    pub cache: Option<HookCache>,
+}
+
+/// Cache configuration for pre-command hooks.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct HookCache {
+    /// File whose SHA256 hash determines whether to run the hook
+    pub key: String,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct PackagesSection {
     #[serde(default)]
@@ -1031,6 +1062,28 @@ pub struct EnvValidation {
     /// Example value (used in .env.example)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<String>,
+}
+
+/// TypeScript configuration for tsconfig generation by `airis gen`.
+///
+/// Controls generation of `tsconfig.base.json` (shared compilerOptions) and
+/// `tsconfig.json` (IDE paths + ignoreDeprecations for TS6).
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct TypescriptSection {
+    /// Override TS major version (auto-detected from catalog if omitted)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
+    /// Extra compilerOptions merged into tsconfig.base.json
+    #[serde(default)]
+    pub compiler_options: IndexMap<String, toml::Value>,
+    /// Extra path aliases merged into root tsconfig.json (IDE)
+    /// key = alias (e.g. "@agiletec/supabase-client"),
+    /// value = path (e.g. "libs/supabase/client/src/index.ts")
+    #[serde(default)]
+    pub paths: IndexMap<String, String>,
+    /// Disable tsconfig generation (default: false)
+    #[serde(default)]
+    pub skip: bool,
 }
 
 /// Runtime configuration for Docker builds


### PR DESCRIPTION
## Summary
- New `[hooks]` section in manifest.toml for running commands before `airis run <task>`
- `pre_command`: any shell command (e.g., `pnpm install`, `pip install -r requirements.txt`)
- `skip`: commands that bypass the hook (e.g., `up`, `down`, `ps`)
- `cache.key`: file whose SHA256 hash determines whether to re-run (e.g., `pnpm-lock.yaml`)
- Docker-first mode: exec → run --rm fallback
- No package-manager-specific logic hardcoded — manifest declares what, CLI handles how

## Test plan
- [x] `cargo test` — 226 tests passing (4 new)
- [x] `cargo check` — no warnings
- [x] Pre-push hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)