### PR TITLE
debug(ci): add cargo package size check to reproduce #125

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -32,3 +34,39 @@ jobs:
 
       - name: Build release
         run: cargo build --release
+
+      - name: Package (debug sizing — replicates crates.io upload environment)
+        run: |
+          set -euo pipefail
+          echo "=== cargo package --list (full file inventory) ==="
+          cargo package --list --allow-dirty
+          echo ""
+          echo "=== Running cargo package --no-verify ==="
+          cargo package --no-verify --allow-dirty
+          echo ""
+          echo "=== Generated .crate size ==="
+          ls -lh target/package/*.crate
+          echo ""
+          echo "=== Uncompressed package dir size (top-level breakdown) ==="
+          CRATE_DIR=$(find target/package -maxdepth 1 -type d -name 'airis-monorepo-*' | head -1)
+          if [ -n "$CRATE_DIR" ]; then
+            du -sh "$CRATE_DIR"
+            echo ""
+            echo "=== Top 20 largest files inside package ==="
+            find "$CRATE_DIR" -type f -printf '%s %p\n' | sort -rn | head -20
+            echo ""
+            echo "=== Size by top-level subdirectory ==="
+            du -sh "$CRATE_DIR"/* 2>/dev/null | sort -rh
+          fi
+          echo ""
+          echo "=== 10MB limit check ==="
+          CRATE_FILE=$(ls target/package/*.crate | head -1)
+          CRATE_BYTES=$(stat -c%s "$CRATE_FILE")
+          LIMIT=10485760
+          echo "Crate size: $CRATE_BYTES bytes"
+          echo "Limit:      $LIMIT bytes"
+          if [ "$CRATE_BYTES" -gt "$LIMIT" ]; then
+            echo "::error::Package exceeds crates.io 10MB limit ($CRATE_BYTES > $LIMIT)"
+            exit 1
+          fi
+          echo "OK: under limit"


### PR DESCRIPTION
## Purpose

PR #138 のマージ後、Release workflow が v3.0.2 で `status 413 Payload Too Large` で失敗した (https://github.com/agiletec-inc/airis-monorepo/actions/runs/24330182666)。ローカル Mac では `.crate` サイズ 236 KB だったのに、CI Linux runner で 10MB を超えている。

この PR は修正ではなく **診断用の debug PR**。CI に package listing と size breakdown の step を追加し、PR の CI run で以下を観測する:

- `cargo package --list` で実際に package に入る全ファイル
- `.crate` ファイルのサイズ
- top 20 largest files と subdirectory ごとのサイズ内訳
- 10MB 制限チェック (超えたら CI 落ちる)

## Why CI and not Release workflow?

Release workflow は `on: push: branches: [main]` と tag trigger で動き、PR checks には含まれない。かつ publish step は失敗してから原因調査するのでは遅すぎる (v3.0.2 タグと GitHub Release が既に作られたように、副作用が大きい)。ci.yml に載せれば PR 時点で検出できる。

## Not a fix — just diagnosis

この PR はマージ **しない** 想定。CI の出力を見て真の肥大化原因を特定したら、この PR は close して、別ブランチで根本修正 PR を作る。

## Related

- Closes nothing (#125 は reopen 済み)
- Related: #125, #121, #140