### PR TITLE
fix: exclude CI artifacts from published crate (#125)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,12 @@ jobs:
             artifacts/airis-* \
             SHA256SUMS.txt
 
+      - name: Clean downloaded artifacts before publish
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          rm -rf artifacts SHA256SUMS.txt
+          ls -la
+
       - name: Publish to crates.io
         if: steps.check_tag.outputs.exists == 'false'
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ exclude = [
     "/docs",
     "/scripts",
     "/npm",
+    # Release workflow side-effects: downloaded artifacts and checksums
+    # must not be packaged into the crate when cargo publish runs in the
+    # same working directory after build artifacts are fetched.
+    "/artifacts",
+    "/SHA256SUMS.txt",
     "**/.DS_Store",
     "/demo.tape",
     "/pnpm-lock.yaml",


### PR DESCRIPTION
## Root cause

v3.0.2 の Release workflow が `status 413 Payload Too Large` で失敗していた本当の原因を、debug PR #141 で追加した package size check を使って特定した。

**Linux vs macOS の差ではない**。CI 環境での package サイズをローカルと同じ条件 (ci.yml、ubuntu-latest) で計測した結果は 237 KB で、10MB 制限の 2.3%。つまり単体では全然問題ない。

**真の原因は Release workflow の release job の構造**:

1. `build` job (5 target matrix) が各 OS/arch 用の airis バイナリを artifact として upload
2. `release` job が `actions/download-artifact@v8` で **全 artifact をリポジトリ root 直下の `./artifacts/` に展開** (.github/workflows/release.yml:153-158)
3. Tag 作成、GitHub Release 作成、その直後に
4. **`cargo publish --allow-dirty`** を **同じワーキングディレクトリ** で実行 (L192)
5. `--allow-dirty` は untracked ファイルを許容するオプションなので、`artifacts/` 配下のバイナリ群 (各 2-3 MB × 5 = 10-15 MB) が **package に全部含まれてしまう**
6. `.crate` のサイズが 10 MB を超え、crates.io が 413 で拒否

`Cargo.toml` の `exclude` に `/artifacts` が入っていなかったため、cargo からは単なる untracked ディレクトリとして扱われ、`--allow-dirty` と組み合わさって package に混入した。ローカル (Mac でも Linux でも) で再現できなかったのは、ローカルには `artifacts/` が存在しないから。

## Changes

### 1. `Cargo.toml` exclude list に `/artifacts` と `/SHA256SUMS.txt` 追加
防御的に、将来の workflow 変更で別の副産物が増えても crate に入らないように。

### 2. `.github/workflows/release.yml` の publish 前に明示的 cleanup 追加
\`\`\`yaml
- name: Clean downloaded artifacts before publish
  if: steps.check_tag.outputs.exists == 'false'
  run: |
    rm -rf artifacts SHA256SUMS.txt
    ls -la
\`\`\`
Cargo.toml 側のガードと二重化。意図を workflow 側でも明示する。

## Verification

- ローカル `cargo package --list --allow-dirty` で `artifacts/` や `SHA256SUMS.txt` が含まれないことを確認
- この PR の CI は #141 で追加した package size check step があるので、以下の項目を自動検証:
  - cargo package --list の全インベントリ
  - .crate サイズ
  - top 20 largest files
  - 10 MB 制限チェック (超えたら CI 失敗)
- ただし **release job の挙動 (artifacts download 後の publish) は PR CI では検証できない** 構造問題が残る (別 issue 化の余地あり、#139 で触れた「PR check に含まれない workflow が本番を決める」の具体例)

## Not fixed by this PR

- v3.0.2 タグと GitHub Release は既に作成済みだが **crates.io への publish は永久に失敗** する (crates.io は同バージョンの再 upload を許可しない)。このマージ後の次のコミットで auto-bump されて v3.0.3 が切られ、その v3.0.3 で初めて publish が成功する想定
- 失敗した v3.0.2 の GitHub Release を削除するかどうかはユーザー判断 (残しておいても実害は小さい)

## Closes

#125 (今度こそ)