### PR TITLE
chore: bump version to 3.0.3 to trigger crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"


### PR DESCRIPTION
## Purpose

PR #142 で crates.io publish 413 エラーの根本原因 (artifacts/ 混入) を修正したが、**v3.0.2 タグは既に切られて crates.io に同バージョンを再 publish することはできない**。そのため #142 の修正が本番で効くかどうかを検証するには、新しいバージョン番号に上げて Release workflow を走らせるしかない。

## What this PR does

- `Cargo.toml` version: 3.0.2 → 3.0.3
- `Cargo.lock` の同期

変更はこの 2 ファイルのみ、他の code 変更は一切含まない。

## Expected flow after merge

1. main に squash merge
2. Release workflow が自動起動 (on: push: branches: [main])
3. Build matrix (5 targets) が artifacts を作成
4. Release job が artifacts download → tag 作成 (v3.0.3) → GitHub Release 作成
5. **`Clean downloaded artifacts before publish` step** (#142 で追加) が `artifacts/` と `SHA256SUMS.txt` を削除
6. `cargo publish --allow-dirty` が走る
7. Cargo.toml の `exclude = [\"/artifacts\", \"/SHA256SUMS.txt\"]` (#142 で追加) が二重ガード
8. crates.io に airis-monorepo v3.0.3 が公開される

## Failure contingency

もし Release workflow が再び失敗した場合:
- v3.0.3 タグと GitHub Release だけが中途半端に作られる (v3.0.2 と同じ傷)
- crates.io は v3.0.3 を永久に publish 不可能になる
- 次は v3.0.4 で再度検証が必要

ただし今回は失敗時の情報も豊富: PR #142 で Cargo.toml に `/artifacts` exclude を入れている (Mac/Linux 両方のローカルで検証済み)、release.yml にも明示 cleanup を入れている。PR #142 の CI で package size 237 KB が実測確認済み。両方が同時に失敗する条件は考えにくい。

## Why a PR instead of direct push?

- main は branch protection がないので技術的には直接 push 可能
- しかし前回 (#138) でマージ後に Release workflow が失敗した失敗の反省から、**全ての main 変更は PR CI を通してから入れる** ポリシーを自分に課す
- version bump だけの commit でも CI が通ることを事前に確認する

## Related

- Closes #125 (実 publish 成功後に自動 close される想定)
- Follows up: #142, #138