### PR TITLE
chore: bump version to 3.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airis-monorepo"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-monorepo"
-version = "3.0.3"
+version = "3.0.4"
 edition = "2024"
 authors = ["Kazuki Nakai <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"


### PR DESCRIPTION
## Summary

Release bump to 3.0.4 so downstream consumers can pull the `.npmrc` cleanup from #144 via crates.io and npm.

## Changes
- `Cargo.toml`: 3.0.3 → 3.0.4
- `Cargo.lock`: regenerated

## Test plan
- [x] `cargo check` passes
- [ ] Release workflow publishes to crates.io + npm after merge (tagged `v3.0.4`)