### PR TITLE
fix(ci): add user-agent to crates.io version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,20 +193,32 @@ jobs:
         if: steps.check_tag.outputs.exists == 'false'
         shell: bash
         run: |
+          set -euo pipefail
           LOCAL="${{ steps.version.outputs.version }}"
-          # Query crates.io for the current max_stable_version.
-          REMOTE=$(curl -sf https://crates.io/api/v1/crates/airis-monorepo \
-            | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["crate"].get("max_stable_version","0.0.0"))' \
-            || echo "0.0.0")
+          # crates.io rejects requests without a descriptive User-Agent.
+          UA="airis-monorepo-release (+https://github.com/agiletec-inc/airis-monorepo)"
+          RESPONSE=$(curl -sf -A "$UA" https://crates.io/api/v1/crates/airis-monorepo || true)
+          if [ -z "$RESPONSE" ]; then
+            echo "⚠️  Failed to query crates.io — skipping publish to avoid regressions."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REMOTE=$(printf '%s' "$RESPONSE" \
+            | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["crate"].get("max_stable_version",""))')
           echo "Local version:  $LOCAL"
           echo "Remote version: $REMOTE"
-          # Compare with sort -V: if LOCAL is strictly greater, we can publish.
+          if [ -z "$REMOTE" ]; then
+            echo "⚠️  crates.io returned no max_stable_version — skipping publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Publish only when LOCAL is strictly higher than REMOTE (semver order).
           HIGHEST=$(printf '%s\n%s\n' "$LOCAL" "$REMOTE" | sort -V | tail -n1)
           if [ "$LOCAL" = "$HIGHEST" ] && [ "$LOCAL" != "$REMOTE" ]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
             echo "Skipping crates.io publish: $LOCAL is not higher than $REMOTE."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to crates.io


### PR DESCRIPTION
## Summary

Follow-up to #147. The crates.io version guard added in that PR wrongly approved the v2.1.0 publish because `curl` hit crates.io without a descriptive User-Agent and got back HTTP 403. `curl -sf` exited non-zero, the `|| echo 0.0.0` fallback fired, and `2.1.0 > 0.0.0` let `cargo publish` run — so v2.1.0 now sits on crates.io as a lower-than-latest version.

## Changes

- Send a descriptive `User-Agent` header so crates.io responds 200 instead of 403
- On any query failure or missing `max_stable_version`, **skip publish** instead of falling back to a synthetic `0.0.0`. An unintended publish is harder to undo than a skipped one.

## Evidence

Reproduced locally:

```
$ curl -sf -w "HTTP %{http_code}\n" -o /dev/null https://crates.io/api/v1/crates/airis-monorepo
# exit 56, HTTP 403  ← default curl UA is rejected

$ curl -sf -w "HTTP %{http_code}\n" -o /dev/null -A "airis-monorepo-release (+https://github.com/...)" https://crates.io/api/v1/crates/airis-monorepo
# HTTP 200
```

## Test plan

- [x] Verified 403 without UA, 200 with project UA against live crates.io
- [ ] After merge: next release workflow run should print `Remote version: <something>` instead of `0.0.0`, and skip publish if LOCAL isn't strictly higher

## Notes

- v2.1.0 is already on crates.io; `cargo install airis-monorepo` still resolves to `4.0.1` because that's `max_stable_version`, so there is no immediate user impact. A future v5.0.0+ release will cleanly take over `max_stable`.