### PR TITLE
chore: yank 3.0.3/3.0.4/4.0.1 from crates.io

### DIFF
--- a/.github/workflows/yank-bad-versions.yml
+++ b/.github/workflows/yank-bad-versions.yml
@@ -1,0 +1,29 @@
+name: Yank bad versions (one-shot cleanup)
+
+# One-shot maintenance workflow to yank crates.io releases that landed as a
+# result of the auto-bump bug fixed in #147. Run via workflow_dispatch, then
+# delete this file via PR.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  yank:
+    name: Yank airis-monorepo 3.0.3 / 3.0.4 / 4.0.1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - name: Yank versions
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -e
+          for v in 3.0.3 3.0.4 4.0.1; do
+            echo "Yanking airis-monorepo@$v"
+            cargo yank --version "$v" airis-monorepo
+          done
+          echo "Done."


### PR DESCRIPTION
## Summary

One-shot maintenance workflow that yanks the crates.io releases which landed because of the auto-bump bug fixed in #147.

## Plan

1. Merge this PR
2. Trigger `Yank bad versions` via workflow_dispatch (Actions tab)
3. Verify on https://crates.io/crates/airis-monorepo that 3.0.3 / 3.0.4 / 4.0.1 are yanked
4. Follow-up PR deletes `.github/workflows/yank-bad-versions.yml`

## Notes

- `cargo yank` is reversible (`cargo yank --undo`), so this is a safe cleanup
- 1.81.0 / 1.81.1 / 2.1.0 are intentionally left alone