### PR TITLE
docs: add operational notes to WORKFLOW and STACK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.3.4"
+version = "3.3.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.3.4"
+version = "3.3.5"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/docs/ai/STACK.md
+++ b/docs/ai/STACK.md
@@ -17,6 +17,8 @@ cargo fmt --check
 cargo clippy -- -D warnings
 ```
 
+`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+
 ## Important Paths
 
 - `src/manifest/` for manifest schema and validation

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -13,3 +13,12 @@
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
 - **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
 - **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+
+## Operational Notes
+
+These are easy to discover the hard way. Read once, save a debugging session.
+
+- **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
+- **The pre-commit hook auto-bumps the version on every commit.** `airis bump-version --auto` rewrites both `Cargo.toml` and `Cargo.lock` in lockstep; do not manually sync the lockfile, the hook handles it. If you ever see Cargo.toml/Cargo.lock drift after a commit, the bump binary is stale — run `cargo install --path .` to refresh it.
+- **The post-commit hook reinstalls the `airis` binary in the background** (`cargo install --path . --quiet 2>/dev/null &`). After committing changes to the CLI itself, the next commit will use the rebuilt binary; manual reinstall is rarely needed.
+- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.


### PR DESCRIPTION
## Summary
- Add four operational notes to `docs/ai/WORKFLOW.md` that fresh contributors / AI agents discover the hard way: main is PR-only, the pre-commit bump-version hook syncs Cargo.toml + Cargo.lock together (don't fight it), the post-commit hook reinstalls the binary in the background, and `airis verify` silently skips runtime checks when the workspace container is offline.
- Add a one-line warning to `docs/ai/STACK.md` so the raw `cargo` commands stay the canonical pre-push gate (since `airis verify` can return green without running them).
- Adapter files (CLAUDE.md / AGENTS.md / GEMINI.md) are unchanged — they are thin pointers, so the new content reaches all vendors automatically.

## Test plan
- [x] `airis docs sync` regenerates the three adapters identically (no diff)
- [x] Pre-commit hook validated end-to-end: bumped Cargo.toml and Cargo.lock together (3.3.4 → 3.3.5), no drift
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)