### PR TITLE
fix(release): publish to crates.io on first run (404 path)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,14 +197,31 @@ jobs:
           LOCAL="${{ steps.version.outputs.version }}"
           # crates.io rejects requests without a descriptive User-Agent.
           UA="airis-workspace-release (+https://github.com/agiletec-inc/airis-workspace)"
-          RESPONSE=$(curl -sf -A "$UA" https://crates.io/api/v1/crates/airis-workspace || true)
-          if [ -z "$RESPONSE" ]; then
-            echo "⚠️  Failed to query crates.io — skipping publish to avoid regressions."
+
+          # Capture HTTP status separately from the body so we can
+          # distinguish "crate has never been published" (404 → publish
+          # the initial version) from transient network failures
+          # (5xx / connection error → skip). The previous version
+          # used `curl -sf || true`, which collapsed both cases into an
+          # empty RESPONSE and created a catch-22 where the very first
+          # publish never ran.
+          HTTP_CODE=$(curl -s -A "$UA" -o /tmp/crates_resp.json \
+            -w '%{http_code}' \
+            https://crates.io/api/v1/crates/airis-workspace || echo "000")
+
+          if [ "$HTTP_CODE" = "404" ]; then
+            echo "Crate not yet on crates.io — performing initial publish for $LOCAL."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "⚠️  crates.io returned HTTP $HTTP_CODE — skipping publish to avoid regressions."
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          REMOTE=$(printf '%s' "$RESPONSE" \
-            | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["crate"].get("max_stable_version",""))')
+
+          REMOTE=$(python3 -c 'import json; d=json.load(open("/tmp/crates_resp.json")); print(d["crate"].get("max_stable_version",""))')
           echo "Local version:  $LOCAL"
           echo "Remote version: $REMOTE"
           if [ -z "$REMOTE" ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.5.0"
+version = "3.5.1"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"


### PR DESCRIPTION
## Summary

The crates.io publish step in `release.yml` has been silently skipping every release because of a catch-22 in the version-check logic.

```bash
RESPONSE=$(curl -sf -A "$UA" https://crates.io/api/v1/crates/airis-workspace || true)
if [ -z "$RESPONSE" ]; then
  echo "⚠️  Failed to query crates.io — skipping publish to avoid regressions."
  echo "should_publish=false" >> "$GITHUB_OUTPUT"
  exit 0
fi
```

`curl -sf` fails (non-zero exit) on **any** 4xx/5xx response. The very first time the workflow runs against a not-yet-published crate, crates.io returns **HTTP 404**, which collapses into the "transient error → skip" branch alongside genuine network failures. The crate therefore can never be published — the first publish never runs, so 404 persists, so the first publish never runs, ad infinitum.

Confirmed: `curl https://crates.io/api/v1/crates/airis-workspace` returns `{"errors":[{"detail":"crate \`airis-workspace\` does not exist"}]}` with HTTP 404, despite the project shipping 3.5.0 GitHub releases since 2026-04-30.

## Fix

Capture the HTTP status code separately from the body and branch on it:

- **404** → "crate has never been published" → `should_publish=true` (initial publish)
- **200** → run the existing semver comparison (publish if local > remote)
- **any other** → genuine error, skip

This preserves all existing behavior for subsequent releases while unblocking the very first publish.

## Why this matters now

`airis-mcp-gateway` is being changed to install the airis CLI via `cargo-binstall airis-workspace`. cargo-binstall starts from crates.io metadata, so it cannot resolve a crate that has never been published — it currently fails with `airis-workspace is not found`. The `[package.metadata.binstall]` block in `Cargo.toml` is correct; the only thing missing is the initial crates.io presence.

After this PR merges, the next release run will publish 3.5.1 to crates.io (per the auto-bump hook), and from then on every release will publish automatically.

## Test plan

- [ ] CI passes
- [ ] After merge: confirm the Release workflow runs the "Publish to crates.io" step (no longer skipped)
- [ ] After merge: verify `https://crates.io/api/v1/crates/airis-workspace` returns 200
- [ ] After merge: verify `cargo binstall airis-workspace --version 3.5.1` succeeds in a clean environment