### PR TITLE
chore: bump to 3.6.3 to re-trigger Homebrew tap publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.6.1"
+version = "3.6.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.6.1"
+version = "3.6.3"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"


### PR DESCRIPTION
## Summary

After #192 reactivated the GitHub App auth path for Homebrew tap publishing, a new tag is required to re-run the Release pipeline against the corrected \`release.yml\`. This patch-bump commit produces \`v3.6.3\` for that purpose.

(Branch name says \`bump-3.5.2\` because that was the planning intent before the auto-bump hook revealed origin/main was already at 3.6.1; I let the hook take precedence over the planned number.)

## Why this matters

- v3.5.1 → crates.io ✅, GH release artifacts ✅, Homebrew tap ❌ (App-auth fix not on origin at tag time)
- v3.6.1 → same situation
- v3.6.3 (this PR + tag) → first release with App-auth active end-to-end

## After merge

\`\`\`
git tag v3.6.3
git push origin v3.6.3
\`\`\`

This re-triggers cargo-dist + publish-crates.yml under the new release.yml. \`vars.HOMEBREW_TAP_PUBLISHER_CLIENT_ID\` and \`secrets.HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY\` are already provisioned at org level.

## Test plan

- [ ] CI passes
- [ ] After tag push: \`publish-homebrew-formula\` succeeds (no Bad credentials)
- [ ] \`agiletec-inc/homebrew-tap\` receives a commit from \`homebrew-tap-publisher[bot]\`
- [ ] crates.io has 3.6.3