### PR TITLE
fix(release): publish Homebrew formula via PR auto-merge (not direct push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,12 +323,27 @@ jobs:
           pattern: artifacts-*
           path: Formula/
           merge-multiple: true
-      # This is extra complex because you can make your Formula name not match your app name
-      # so we need to find releases with a *.rb file, and publish with that filename.
-      - name: Commit formula files
+      # === MANUAL CUSTOMIZATION — re-apply after `dist generate` ===
+      # cargo-dist's template ends with `git push` directly to the tap's
+      # default branch. The org-level "Main Branch Protection" ruleset
+      # (combined with `Homebrew tap protection` on this repo) requires
+      # changes to land via pull request. The publisher App is registered
+      # as a `bypass_actor` with `bypass_mode: pull_request`, so it can
+      # bypass the "0 required reviews are not yet satisfied" friction —
+      # but it still has to go through a PR. Hence: branch + PR + immediate
+      # squash-merge below. See dist-workspace.toml for the maintenance
+      # note pointing at this customization.
+      - name: Commit formula on a release branch and merge via PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ needs.plan.outputs.tag }}
         run: |
+          set -euo pipefail
           git config --global user.name "${GITHUB_USER}"
           git config --global user.email "${GITHUB_EMAIL}"
+
+          BRANCH="release/formula-${TAG}"
+          git checkout -b "$BRANCH"
 
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
             filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
@@ -343,7 +358,22 @@ jobs:
             git add "Formula/${filename}"
             git commit -m "${name} ${version}"
           done
-          git push
+
+          git push --set-upstream origin "$BRANCH"
+
+          PR_TITLE="chore(formula): update for ${TAG}"
+          PR_BODY="Automated formula update produced by the \`Release\` workflow on \`agiletec-inc/airis-workspace@${TAG}\`. The publisher App (\`agiletec-inc-homebrew-publisher\`) is the bypass actor for \`Homebrew tap protection\`; this PR is merged immediately because the ruleset has \`required_approving_review_count: 0\` and the App is in \`bypass_mode: pull_request\`."
+
+          PR_URL=$(gh pr create \
+            --base "$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)" \
+            --head "$BRANCH" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY")
+
+          # Immediate squash-merge. With required_reviews=0 + App bypass +
+          # no required status checks, --auto is unnecessary and would
+          # require the repo's "Allow auto-merge" setting to be enabled.
+          gh pr merge --squash --delete-branch "$PR_URL"
 
   announce:
     needs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.6.4"
+version = "3.6.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.6.4"
+version = "3.6.5"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -2,14 +2,26 @@
 members = ["cargo:."]
 
 # === MAINTENANCE NOTE ===
-# `.github/workflows/release.yml` has a hand-applied customization in the
-# `publish-homebrew-formula` job: it mints a GitHub App installation token
-# from the org-shared `homebrew-tap-publisher` App (org var
-# HOMEBREW_TAP_PUBLISHER_CLIENT_ID + org secret
-# HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY) instead of using the static PAT
-# (HOMEBREW_TAP_TOKEN) that cargo-dist's template hard-codes.
-# After running `dist init` or `dist generate`, re-apply that diff —
-# search for the "MANUAL CUSTOMIZATION" marker in release.yml.
+# `.github/workflows/release.yml` has TWO hand-applied customizations
+# in the `publish-homebrew-formula` job:
+#
+#  1. App-token auth: mints a GitHub App installation token from the
+#     org-shared `agiletec-inc-homebrew-publisher` App (org var
+#     HOMEBREW_TAP_PUBLISHER_CLIENT_ID + org secret
+#     HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY) instead of the static PAT
+#     (HOMEBREW_TAP_TOKEN) that cargo-dist's template hard-codes.
+#
+#  2. Branch + PR + auto-merge instead of direct push: the
+#     `agiletec-inc/homebrew-tap` repo is protected by an org-level
+#     ruleset (`Main Branch Protection`, `homebrew-tap` excluded) plus
+#     a repo-level ruleset (`Homebrew tap protection`) which requires
+#     pull requests on the default branch. The publisher App is
+#     registered as a bypass actor with `bypass_mode: pull_request`,
+#     so the workflow has to use a PR — but the PR auto-merges because
+#     `required_approving_review_count: 0` + the App's bypass.
+#
+# After running `dist init` or `dist generate`, re-apply both diffs —
+# search for the "MANUAL CUSTOMIZATION" markers in release.yml.
 
 # Config for 'dist'
 [dist]


### PR DESCRIPTION
## Why

v3.6.3's release run got past App auth and built the formula commit locally, then died at:

\`\`\`
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
\`\`\`

The org-level \`Main Branch Protection\` ruleset (PR required, no bypass) applies to every repo. Direct push to \`homebrew-tap/main\` was never going to work, regardless of App auth.

## Architecture (Plan F per official-docs research)

Layered Rulesets aggregate, they don't override — so the cleanest path is:

| Layer | Change |
|---|---|
| Org ruleset \`Main Branch Protection\` (id 13075497) | \`conditions.repository_name.exclude += ["homebrew-tap"]\` — no longer governs the tap repo |
| New repo-level ruleset \`Homebrew tap protection\` (id 15826021) on \`homebrew-tap\` | rules: deletion + non_fast_forward + pull_request(0 reviews); bypass_actors: \`agiletec-inc-homebrew-publisher\` (id 3566064) with \`bypass_mode: pull_request\` |
| Workflow \`publish-homebrew-formula\` | branch + \`gh pr create\` + immediate \`gh pr merge --squash\` instead of \`git push origin main\` |

Net effect:
- \`homebrew-tap\` is **still protected** (no force pushes, no deletion, PR required) — security is not weakened
- The publisher App is the **only** actor that can bypass the review requirement, and only via PR (audit trail in PRs)
- Influence is **physically scoped to one repo** (the App is installed org-wide but only this repo's ruleset names it as a bypass actor)

## Why \`bypass_mode: pull_request\` and not \`always\`

\`pull_request\` forces every formula update to land as a PR — clear audit trail in repo activity, easier to revert. \`always\` would have allowed direct pushes (matching cargo-dist's stock template) but loses the PR record. The user-facing trade-off is a small workflow change vs. losing review-able history; we picked the audit trail.

## Files

- \`.github/workflows/release.yml\` — \`publish-homebrew-formula\` job rewrites the final commit/push step into branch + PR + auto-merge. Uses the App token for both \`actions/checkout\` AND \`gh\` (via \`GH_TOKEN\` env), so all PR ops are attributed to the App.
- \`dist-workspace.toml\` — maintenance note now lists BOTH manual customizations (App auth + PR-based merge) so a future \`dist generate\` run is told to re-apply both.

## Out-of-band changes (already applied to live infra)

- \`gh api -X PUT orgs/agiletec-inc/rulesets/13075497\` — added \`homebrew-tap\` to exclude
- \`gh api -X POST repos/agiletec-inc/homebrew-tap/rulesets\` — created \`Homebrew tap protection\`

Both are already live; this PR just makes the workflow match.

## Test plan

- [x] \`dist plan\` exit 0 (no diff against config)
- [ ] CI green on this PR
- [ ] After merge: bump tag (the failed v3.6.3 won't pick up this workflow change — re-running its workflow uses the workflow as-of the run's commit). Push v3.6.5 (or whatever Cargo.toml lands at after merge) and watch the new pipeline.
- [ ] Verify: PR appears in \`agiletec-inc/homebrew-tap\` from \`agiletec-inc-homebrew-publisher[bot]\`, auto-merges, \`Formula/airis-workspace.rb\` lands on main.
- [ ] \`brew tap agiletec-inc/tap && brew install airis-workspace\`

## Side note

Pre-commit hook bumped Cargo.toml to 3.6.5 again (reads previous commit's message — the merged \`feat:\` from #189). Out of scope here. Next release will be whatever Cargo.toml says at tag time.