### PR TITLE
fix(release): make publish-homebrew-formula rerun-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,6 +345,14 @@ jobs:
           BRANCH="release/formula-${TAG}"
           git checkout -b "$BRANCH"
 
+          # Rerun safety: if a previous attempt pushed this branch but
+          # crashed before merging, the remote ref blocks fast-forward
+          # on retry. Delete the stale remote ref before pushing so the
+          # workflow is idempotent. The repo-level `non_fast_forward`
+          # rule applies only to the default branch (~DEFAULT_BRANCH),
+          # so feature-branch deletion is allowed.
+          gh api -X DELETE "repos/agiletec-inc/homebrew-tap/git/refs/heads/${BRANCH}" 2>/dev/null || true
+
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
             filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
             name=$(echo "$filename" | sed "s/\.rb$//")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.6.6"
+version = "3.6.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.6.5"
+version = "3.6.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.6.5"
+version = "3.6.6"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.6.6"
+version = "3.6.7"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/guards/tests.rs
+++ b/src/commands/guards/tests.rs
@@ -1,7 +1,3 @@
-use super::*;
-
-use std::fs;
-
 use crate::manifest::{GlobalConfig, GuardLevel};
 
 #[test]


### PR DESCRIPTION
## Why

v3.6.5's first publish-homebrew-formula attempt failed at `gh pr create` (App was missing `pull_requests: write`). The branch was already pushed to homebrew-tap before the crash. On retry the branch couldn't fast-forward and `gh run rerun --failed` died with "Updates were rejected". Required manual cleanup (`gh api -X DELETE` on the orphan ref) to unblock the rerun.

This makes the workflow self-healing for that exact scenario.

## What changes

Before `git push`, delete the remote ref if it exists:

```yaml
gh api -X DELETE "repos/agiletec-inc/homebrew-tap/git/refs/heads/${BRANCH}" 2>/dev/null || true
```

The repo-level `non_fast_forward` rule on homebrew-tap is scoped to `~DEFAULT_BRANCH` only, so feature-branch deletion is allowed.

## Test plan

- [x] `dist plan` exit 0
- [ ] CI green
- [ ] (Implicit) Future reruns of any release that pushed-but-didn't-merge can recover without manual ref deletion.