### PR TITLE
feat(manifest): introduce [runtimes] declarative section (Phase 1a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.6.10"
+version = "3.6.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.6.10"
+version = "3.6.11"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -133,8 +133,8 @@ pub(crate) mod defaults {
     pub const RUST_IMAGE: &str = "rust:1.88-slim";
 
     // Python
-    pub const PYTHON_VERSION: &str = "3.12";
-    pub const PYTHON_IMAGE: &str = "python:3.12-slim";
+    pub const PYTHON_VERSION: &str = "3.13";
+    pub const PYTHON_IMAGE: &str = "python:3.13-slim";
 
     // Alpine (for minimal runtime stages)
     pub const ALPINE_VERSION: &str = "3.21";

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -40,6 +40,7 @@ impl Manifest {
             toml::from_str(content).with_context(|| "Failed to parse manifest.toml")?;
 
         manifest.migrate_testing_to_policy();
+        manifest.warn_runtime_image_overlap();
 
         if let Err(e) = manifest.validate() {
             eprintln!(
@@ -61,6 +62,7 @@ impl Manifest {
 
         // [testing] → [policy.testing] migration fallback
         manifest.migrate_testing_to_policy();
+        manifest.warn_runtime_image_overlap();
 
         manifest.validate()?;
         manifest.resolve_conventions();
@@ -76,6 +78,27 @@ impl Manifest {
         }
 
         Ok(manifest)
+    }
+
+    /// Warn when [workspace].image and [runtimes].node both define the Node version.
+    ///
+    /// Phase 1a only emits an advisory; the workspace Dockerfile generator that
+    /// honours [runtimes] lands in Phase 1c. Until then [workspace].image keeps
+    /// driving Node selection so existing manifests stay byte-identical.
+    fn warn_runtime_image_overlap(&self) {
+        let default_image = crate::channel::defaults::NODE_LTS_IMAGE;
+        let workspace_image_overridden = self.workspace.image != default_image;
+
+        if let Some(node) = &self.runtimes.node
+            && workspace_image_overridden
+        {
+            eprintln!(
+                "⚠️  Both [workspace] image (\"{}\") and [runtimes.node] (\"{}\") are set. \
+                 Phase 1c will pick [runtimes.node]; [workspace] image is deprecated.",
+                self.workspace.image,
+                node.version()
+            );
+        }
     }
 
     /// Migrate top-level [testing] to [policy.testing] with deprecation warning.

--- a/src/manifest/schema.rs
+++ b/src/manifest/schema.rs
@@ -1829,12 +1829,94 @@ pub struct TemplateConfig {
     pub package_config: String,
 }
 
-/// Runtime aliases configuration
+/// Runtime declarations.
+///
+/// Two responsibilities live here:
+/// 1. `alias` — short aliases consumed by `airis new` (e.g., "py" -> "fastapi").
+/// 2. `node` / `python` / `rust` — declarative runtime versions consumed by
+///    workspace Dockerfile generation and `airis exec` cmd→service routing
+///    (Phase 1 onward; see docs/ai/IDEAL_STATE.md §2 and the eager-floating-book plan).
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct RuntimesSection {
-    /// Short aliases for runtimes (e.g., "py" -> "fastapi", "ts" -> "hono")
+    /// Short aliases for `airis new` templates (e.g., "py" -> "fastapi", "ts" -> "hono")
     #[serde(default)]
     pub alias: IndexMap<String, String>,
+    /// Node runtime to provision inside the workspace container.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node: Option<RuntimeSpec>,
+    /// Python runtime to provision inside the workspace container.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub python: Option<RuntimeSpec>,
+    /// Rust toolchain to provision inside the workspace container.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rust: Option<RuntimeSpec>,
+}
+
+/// A runtime declaration. Accepts either a bare version string or a detailed table.
+///
+/// ```toml
+/// [runtimes]
+/// node = "24"                     # short form
+///
+/// [runtimes.python]
+/// version = "3.13"
+/// package_manager = "uv"
+/// ```
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum RuntimeSpec {
+    /// Bare version string, e.g., `node = "24"`
+    Short(String),
+    /// Detailed table with version + optional image / package_manager / components
+    Detailed(RuntimeDetail),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct RuntimeDetail {
+    pub version: String,
+    /// Override the resolved base image (e.g., `python:3.13-slim`). Default: derived from version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Package manager hint for ecosystems with multiple options (Python: uv|pip|poetry).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_manager: Option<String>,
+    /// Toolchain components (e.g., Rust: ["clippy", "rustfmt"]).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub toolchain_components: Vec<String>,
+}
+
+impl RuntimeSpec {
+    /// Returns the version string for this runtime spec.
+    pub fn version(&self) -> &str {
+        match self {
+            RuntimeSpec::Short(v) => v.as_str(),
+            RuntimeSpec::Detailed(d) => d.version.as_str(),
+        }
+    }
+
+    /// Returns the explicitly overridden image, if any.
+    pub fn image_override(&self) -> Option<&str> {
+        match self {
+            RuntimeSpec::Short(_) => None,
+            RuntimeSpec::Detailed(d) => d.image.as_deref(),
+        }
+    }
+
+    /// Returns the explicit package manager hint, if any.
+    pub fn package_manager(&self) -> Option<&str> {
+        match self {
+            RuntimeSpec::Short(_) => None,
+            RuntimeSpec::Detailed(d) => d.package_manager.as_deref(),
+        }
+    }
+
+    /// Returns toolchain components (empty for `Short`).
+    pub fn toolchain_components(&self) -> &[String] {
+        match self {
+            RuntimeSpec::Short(_) => &[],
+            RuntimeSpec::Detailed(d) => &d.toolchain_components,
+        }
+    }
 }
 
 // =============================================================================

--- a/src/manifest/tests.rs
+++ b/src/manifest/tests.rs
@@ -964,3 +964,114 @@ fn test_levenshtein_distance() {
     assert_eq!(levenshtein_distance("lst", "lts"), 2);
     assert_eq!(levenshtein_distance("react", "latest"), 5);
 }
+
+// =============================================================================
+// [runtimes] declarative section (Phase 1a)
+// =============================================================================
+
+#[test]
+fn runtimes_section_defaults_to_empty() {
+    let manifest = load_from_str(&minimal_manifest()).unwrap();
+    assert!(manifest.runtimes.alias.is_empty());
+    assert!(manifest.runtimes.node.is_none());
+    assert!(manifest.runtimes.python.is_none());
+    assert!(manifest.runtimes.rust.is_none());
+}
+
+#[test]
+fn runtimes_section_parses_short_form() {
+    let toml = r#"
+version = 1
+[project]
+id = "rt"
+
+[runtimes]
+node = "24"
+python = "3.13"
+rust = "1.88"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let node = manifest.runtimes.node.as_ref().unwrap();
+    assert_eq!(node.version(), "24");
+    assert!(node.image_override().is_none());
+    assert!(node.package_manager().is_none());
+    assert!(node.toolchain_components().is_empty());
+
+    assert_eq!(manifest.runtimes.python.as_ref().unwrap().version(), "3.13");
+    assert_eq!(manifest.runtimes.rust.as_ref().unwrap().version(), "1.88");
+}
+
+#[test]
+fn runtimes_section_parses_detailed_form() {
+    let toml = r#"
+version = 1
+[project]
+id = "rt"
+
+[runtimes.python]
+version = "3.13"
+package_manager = "uv"
+image = "python:3.13-slim"
+
+[runtimes.rust]
+version = "1.88"
+toolchain_components = ["clippy", "rustfmt"]
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let py = manifest.runtimes.python.as_ref().unwrap();
+    assert_eq!(py.version(), "3.13");
+    assert_eq!(py.package_manager(), Some("uv"));
+    assert_eq!(py.image_override(), Some("python:3.13-slim"));
+
+    let rust = manifest.runtimes.rust.as_ref().unwrap();
+    assert_eq!(rust.toolchain_components(), &["clippy", "rustfmt"]);
+}
+
+#[test]
+fn runtimes_section_alias_remains_backward_compatible() {
+    let toml = r#"
+version = 1
+[project]
+id = "rt"
+
+[runtimes.alias]
+py = "fastapi"
+ts = "hono"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    assert_eq!(
+        manifest.runtimes.alias.get("py").map(String::as_str),
+        Some("fastapi")
+    );
+    assert_eq!(
+        manifest.runtimes.alias.get("ts").map(String::as_str),
+        Some("hono")
+    );
+    assert!(manifest.runtimes.node.is_none());
+}
+
+#[test]
+fn runtimes_section_round_trips_through_toml() {
+    let toml = r#"
+version = 1
+[project]
+id = "rt"
+
+[runtimes]
+node = "24"
+
+[runtimes.python]
+version = "3.13"
+package_manager = "uv"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let serialized = toml::to_string(&manifest).unwrap();
+    // Round-trip: re-parsing the serialized form must preserve runtime versions.
+    let reparsed: Manifest = toml::from_str(&serialized).unwrap();
+    assert_eq!(reparsed.runtimes.node.as_ref().unwrap().version(), "24");
+    assert_eq!(reparsed.runtimes.python.as_ref().unwrap().version(), "3.13");
+    assert_eq!(
+        reparsed.runtimes.python.as_ref().unwrap().package_manager(),
+        Some("uv")
+    );
+}


### PR DESCRIPTION
## Summary

Phase 1a of the [guards & Docker-first re-design plan](https://github.com/agiletec-inc/airis-workspace/blob/main/docs/ai/IDEAL_STATE.md). Lays the schema groundwork for upcoming PRs:

- **Phase 1b**: \`airis exec <cmd>\` cmd→service auto-resolve + container auto-up.
- **Phase 1c**: workspace Dockerfile multi-runtime generation driven by \`[runtimes]\`.

This PR ships **no behaviour change** — only schema additions, a Python default version bump, and an advisory when \`[workspace].image\` and \`[runtimes.node]\` overlap.

## Schema additions

\`RuntimesSection\` gains three new optional slots:

\`\`\`toml
[runtimes]
node = \"24\"          # Short form
python = \"3.13\"

[runtimes.python]    # Detailed form
version = \"3.13\"
package_manager = \"uv\"
image = \"python:3.13-slim\"

[runtimes.rust]
version = \"1.88\"
toolchain_components = [\"clippy\", \"rustfmt\"]
\`\`\`

\`RuntimeSpec\` is an untagged enum (\`Short(String)\` / \`Detailed(RuntimeDetail)\`) so both forms parse from the same field. The existing \`alias\` field is preserved for \`airis new\` template lookup.

## Channel default bump

- Python \`3.12\` → \`3.13\` — matches the host runtime users are pinning to keep macOS system Python uncontaminated.
- Rust stays at \`1.88\`. The original plan called for \`1.85\` but in-repo \`Cargo.toml\` uses edition 2024 which requires \`>= 1.88\`. The constraint is already documented in \`channel.rs\`.

## Compatibility

\`Manifest::parse\` and \`parse_loose\` now call \`warn_runtime_image_overlap\` — emits an advisory only when both \`[workspace].image\` (overridden) and \`[runtimes.node]\` are set. Existing manifests stay byte-identical; no behaviour change is shipped here.

## Test plan

- [x] \`cargo test --lib\` 329 pass (5 new \`manifest::tests::runtimes_section_*\`)
- [x] \`cargo test --tests\` 20 pass
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -D warnings\` clean
- [x] \`airis test\` clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)