### PR TITLE
feat(exec): cmd→service auto-routing + container auto-up (Phase 1b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,122 @@
+<!-- BEGIN GENERATED airis gen -->
+## Shared Rules (Auto-generated)
+Primary project instructions. Read these first.
+
+### Source: docs/ai/PROJECT_RULES.md
+
+# Project Rules
+
+## Architectural Boundaries
+
+Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygiene Enforcer**. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Its primary value is ensuring a host-hygienic Docker development environment through automated orchestration.
+
+## Design Principles
+
+- **Principle 1: Convention first, manifest second, inference last.**
+  The existence and basic properties of projects are derived from repository structure (e.g., `apps/*`, `libs/*`). `manifest.toml` is used for overrides.
+- **Principle 2: Manifest declares intent and exceptions, not everything.**
+  The manifest should be "thin". Avoid redundant declarations. Use it to specify frameworks, custom ports, or explicit dependencies that cannot be inferred.
+- **Principle 3: Generated files are outputs, not the primary source of truth.**
+  `package.json` (partial), `compose.yaml`, and `tsconfig.json` are artifacts generated to maintain environmental integrity. 
+- **Principle 4: Discovery and scanning never overwrite explicit intent.**
+  Import scanning and automatic detection are advisory mechanisms. They may suggest missing dependencies or configurations but must never overwrite explicit definitions in `manifest.toml` or manual edits in `package.json` (for dependencies/scripts).
+
+## Source Of Truth
+...
+
+## Non-Negotiables
+
+- For **runtime application** configuration (DB-backed settings, tenant boundaries, feature flags), follow `docs/ai/architecture-invariants.md` alongside this file—`manifest.toml` remains the SoT for workspace tooling, not for per-app DB config.
+- Preserve the Docker-first value proposition of airis. Changes must not weaken command guards or make host-side workflows the default path.
+- Keep `airis gen` and the `workspace_init`/`manifest_apply` MCP tools safe by default. Avoid destructive overwrites unless the feature explicitly supports backups or opt-in replacement.
+- Prefer minimal, reviewable diffs. When changing generation or enforcement logic, document the intended invariant.
+
+## Editing Guidance
+
+- Keep `manifest.toml` schema changes backward-compatible when possible.
+- Vendor-specific AI files such as `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` should remain thin adapters that point to shared docs.
+- Reusable task guidance belongs in playbooks or skills, not in the adapter files.
+
+
+### Source: docs/ai/WORKFLOW.md
+
+# Workflow
+
+## Default Flow
+
+1. **Research**: Read the relevant shared docs and inspect the current repository structure. Airis uses conventions (apps/*, libs/*) to automatically detect projects.
+2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis gen` to sync.
+3. **Dependencies (package.json)**: If you need to add libraries, edit the project's `package.json` directly. Airis preserves your edits.
+4. **Execution**: Always use `airis up` to start the environment. It ensures configuration is synced and dependencies are installed inside Docker.
+5. **Verification**: Run `airis verify` before finishing a task to ensure environment integrity and quality gates.
+
+## Design Bias
+
+- **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
+- **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
+- **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+
+## Operational Notes
+
+These are easy to discover the hard way. Read once, save a debugging session.
+
+- **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
+- **The pre-commit hook auto-bumps the version on every commit.** `airis bump-version --auto` rewrites both `Cargo.toml` and `Cargo.lock` in lockstep; do not manually sync the lockfile, the hook handles it. If you ever see Cargo.toml/Cargo.lock drift after a commit, the bump binary is stale — run `cargo install --path .` to refresh it.
+- **The post-commit hook reinstalls the `airis` binary in the background** (`cargo install --path . --quiet 2>/dev/null &`). After committing changes to the CLI itself, the next commit will use the rebuilt binary; manual reinstall is rarely needed.
+- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.
+
+
+### Source: docs/ai/REVIEW.md
+
+# Review
+
+## Primary Checks
+
+- Does the change preserve or strengthen Docker-first enforcement?
+- Does it keep `manifest.toml` authoritative for workspace and guard behavior?
+- Are generated files or adapters clearly marked and reproducible?
+- Are vendor-specific differences isolated instead of duplicated into shared docs?
+
+## Verification Expectations
+
+- Run the smallest relevant Rust tests for touched commands and manifest behavior.
+- If CLI output or serialization changes, verify the command path directly.
+- Call out gaps when a full integration check is too expensive for the current change.
+
+
+### Source: docs/ai/STACK.md
+
+# Stack
+
+## Repository Shape
+
+- This repository is a Rust CLI project.
+- The primary binary is `airis`.
+- `manifest.toml` drives workspace discovery, generation, orchestration, guards, and related automation.
+
+## Common Commands
+
+```bash
+cargo build
+cargo build --release
+cargo test
+cargo test <name>
+cargo fmt --check
+cargo clippy -- -D warnings
+```
+
+`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+
+## Important Paths
+
+- `src/manifest/` for manifest schema and validation
+- `src/commands/` for CLI behavior
+- `docs/ai/` for shared AI guidance
+- `hooks/` for native git hooks
+
+
+<!-- END GENERATED -->
+
 # CLAUDE.md
 
 This file is generated by `airis docs sync`. Keep this file short; the shared docs are the source of truth.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.6.11"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.7.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.6.11"
+version = "3.7.0"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.7.0"
+version = "3.11.0"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/manifest.toml
+++ b/manifest.toml
@@ -45,11 +45,23 @@ strategy = "conventional-commits"
 source = "VERSION"
 sync_targets = ["Cargo.toml"]
 
-[docs]
-sources = [
+[ai]
+shared_rules = [
     "docs/ai/PROJECT_RULES.md",
     "docs/ai/WORKFLOW.md",
     "docs/ai/REVIEW.md",
     "docs/ai/STACK.md",
 ]
-vendors = ["claude"]
+
+[ai.claude]
+target = "CLAUDE.md"
+rules_dir = ".claude/rules/generated/"
+
+[ai.codex]
+target = "AGENTS.md"
+
+[ai.gemini]
+target = "GEMINI.md"
+
+[ai.cursor]
+rules_dir = ".cursor/rules/"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -282,10 +282,27 @@ pub enum Commands {
         tail: Option<u32>,
     },
 
-    /// Execute command in a service container
+    /// Execute a command in a workspace service container.
+    ///
+    /// Service is auto-resolved from the command's runtime family
+    /// (pnpm/npm/node → workspace, python/uv → workspace, cargo → workspace).
+    /// Override with `--service`, or pass a service name as the first
+    /// positional argument for backward compatibility:
+    ///
+    /// ```text
+    /// airis exec pnpm install              # auto-route
+    /// airis exec --service api ls          # explicit
+    /// airis exec workspace pnpm install    # legacy positional form
+    /// ```
     Exec {
-        service: String,
-        #[arg(trailing_var_arg = true)]
+        /// Explicit service to exec into (takes precedence over auto-routing).
+        #[arg(long, short = 's')]
+        service: Option<String>,
+        /// Skip the auto-up that runs when the resolved service is stopped.
+        #[arg(long)]
+        no_auto_up: bool,
+        /// Command and its arguments.
+        #[arg(trailing_var_arg = true, required = true, allow_hyphen_values = true)]
         cmd: Vec<String>,
     },
 

--- a/src/commands/generate/ai_gen.rs
+++ b/src/commands/generate/ai_gen.rs
@@ -1,0 +1,274 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::manifest::Manifest;
+
+const BEGIN_BLOCK: &str = "<!-- BEGIN GENERATED airis gen -->";
+const END_BLOCK: &str = "<!-- END GENERATED -->";
+
+/// Sync AI tool rules from shared sources to tool-specific targets.
+///
+/// This implements the Single Source of Truth (SSOT) for AI rules as specified
+/// in IDEAL_STATE.md §5. It manages CLAUDE.md, AGENTS.md, GEMINI.md,
+/// and individual rule files for Cursor and Claude.
+pub fn sync_ai_rules(manifest: &Manifest, generated_paths: &mut Vec<String>) -> Result<()> {
+    if manifest.ai.shared_rules.is_empty() {
+        return Ok(());
+    }
+
+    // 1. Claude Code
+    if let Some(claude) = &manifest.ai.claude {
+        generate_vendor_target(
+            &claude.target,
+            &manifest.ai.shared_rules,
+            "claude",
+            generated_paths,
+        )?;
+        sync_individual_rules(
+            &claude.rules_dir,
+            &manifest.ai.shared_rules,
+            generated_paths,
+        )?;
+    }
+
+    // 2. Codex (AGENTS.md)
+    if let Some(codex) = &manifest.ai.codex {
+        generate_vendor_target(
+            &codex.target,
+            &manifest.ai.shared_rules,
+            "codex",
+            generated_paths,
+        )?;
+    }
+
+    // 3. Gemini (GEMINI.md)
+    if let Some(gemini) = &manifest.ai.gemini {
+        generate_vendor_target(
+            &gemini.target,
+            &manifest.ai.shared_rules,
+            "gemini",
+            generated_paths,
+        )?;
+    }
+
+    // 4. Cursor (.cursor/rules/)
+    if let Some(cursor) = &manifest.ai.cursor {
+        sync_individual_rules(
+            &cursor.rules_dir,
+            &manifest.ai.shared_rules,
+            generated_paths,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn resolve_path(path_str: &str) -> Result<PathBuf> {
+    if let Some(rest) = path_str.strip_prefix("~/") {
+        let home = dirs::home_dir().context("Could not determine home directory")?;
+        Ok(home.join(rest))
+    } else if let Some(rest) = path_str.strip_prefix('~') {
+        let home = dirs::home_dir().context("Could not determine home directory")?;
+        Ok(home.join(rest))
+    } else {
+        // Note: We don't strip leading / here because it would break absolute paths
+        // used in tests (tempdir). Users should use relative paths in manifest.toml
+        // for repo-internal targets (e.g., ".claude/CLAUDE.md" instead of "/.claude/CLAUDE.md").
+        Ok(PathBuf::from(path_str))
+    }
+}
+
+fn generate_vendor_target(
+    target_path_str: &str,
+    sources: &[String],
+    vendor: &str,
+    generated_paths: &mut Vec<String>,
+) -> Result<()> {
+    let target_path = resolve_path(target_path_str)?;
+
+    let generated_content = render_combined_sources(sources, vendor)?;
+
+    let full_content = if target_path.exists() {
+        let existing = fs::read_to_string(&target_path)?;
+        update_generated_block(&existing, &generated_content)?
+    } else {
+        format!("{}\n{}\n{}\n", BEGIN_BLOCK, generated_content, END_BLOCK)
+    };
+
+    if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&target_path, full_content)
+        .with_context(|| format!("Failed to write {}", target_path.display()))?;
+    generated_paths.push(target_path_str.to_string());
+
+    println!(
+        "   {} Syncing {} ({} sources)",
+        "→".dimmed(),
+        target_path_str.cyan(),
+        sources.len()
+    );
+
+    Ok(())
+}
+
+fn render_combined_sources(sources: &[String], _vendor: &str) -> Result<String> {
+    let mut lines = Vec::new();
+
+    lines.push("## Shared Rules (Auto-generated)".to_string());
+    lines.push("Primary project instructions. Read these first.".to_string());
+    lines.push(String::new());
+
+    for source in sources {
+        if Path::new(source).exists() {
+            let content = fs::read_to_string(source)?;
+            lines.push(format!("### Source: {}", source));
+            lines.push(String::new());
+            lines.push(content);
+            lines.push(String::new());
+        } else {
+            println!(
+                "   {} Rule source not found: {}",
+                "⚠️".yellow(),
+                source.dimmed()
+            );
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn update_generated_block(existing: &str, new_gen: &str) -> Result<String> {
+    let begin_idx = existing.find(BEGIN_BLOCK);
+    let end_idx = existing.find(END_BLOCK);
+
+    match (begin_idx, end_idx) {
+        (Some(start), Some(end)) => {
+            let mut result = existing[..start].to_string();
+            result.push_str(BEGIN_BLOCK);
+            result.push('\n');
+            result.push_str(new_gen);
+            result.push('\n');
+            result.push_str(END_BLOCK);
+            result.push_str(&existing[end + END_BLOCK.len()..]);
+            Ok(result)
+        }
+        _ => {
+            // Block not found, prepend it at the top
+            let mut result = format!("{}\n{}\n{}\n\n", BEGIN_BLOCK, new_gen, END_BLOCK);
+            result.push_str(existing);
+            Ok(result)
+        }
+    }
+}
+
+fn sync_individual_rules(
+    rules_dir_str: &str,
+    sources: &[String],
+    generated_paths: &mut Vec<String>,
+) -> Result<()> {
+    let rules_dir = resolve_path(rules_dir_str)?;
+
+    fs::create_dir_all(&rules_dir)
+        .with_context(|| format!("Failed to create {}", rules_dir.display()))?;
+
+    for source in sources {
+        let source_path = Path::new(source);
+        if !source_path.exists() {
+            continue;
+        }
+
+        let file_name = source_path.file_name().unwrap();
+        let target_path = rules_dir.join(file_name);
+
+        fs::copy(source_path, &target_path)?;
+        generated_paths.push(format!(
+            "{}/{}",
+            rules_dir_str.trim_end_matches('/'),
+            file_name.to_string_lossy()
+        ));
+    }
+
+    println!(
+        "   {} Generated rules in {}",
+        "→".dimmed(),
+        rules_dir_str.cyan()
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::ClaudeAIConfig;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_update_generated_block_new() {
+        let existing = "# Manual Header\n\nSome manual content.";
+        let new_gen = "## New Rules\nRule 1\nRule 2";
+        let updated = update_generated_block(existing, new_gen).unwrap();
+
+        assert!(updated.starts_with(BEGIN_BLOCK));
+        assert!(updated.contains(new_gen));
+        assert!(updated.contains(END_BLOCK));
+        assert!(updated.contains("# Manual Header"));
+        assert!(updated.contains("Some manual content."));
+    }
+
+    #[test]
+    fn test_update_generated_block_existing() {
+        let existing = format!(
+            "# Header\n\n{}\nOld Rules\n{}\n\n# Footer\nManual content.",
+            BEGIN_BLOCK, END_BLOCK
+        );
+        let new_gen = "New Rules Content";
+        let updated = update_generated_block(&existing, new_gen).unwrap();
+
+        assert!(updated.contains("# Header"));
+        assert!(updated.contains(BEGIN_BLOCK));
+        assert!(updated.contains(new_gen));
+        assert!(!updated.contains("Old Rules"));
+        assert!(updated.contains(END_BLOCK));
+        assert!(updated.contains("# Footer"));
+        assert!(updated.contains("Manual content."));
+    }
+
+    #[test]
+    fn test_sync_ai_rules_idempotent() -> Result<()> {
+        let dir = tempdir()?;
+        let source_file = dir.path().join("rules.md");
+        fs::write(&source_file, "Source rule content")?;
+
+        let target_file = dir.path().join("CLAUDE.md");
+        fs::write(&target_file, "# Manual Title\n")?;
+
+        let mut manifest = Manifest::default_with_project("test");
+        manifest.ai.shared_rules = vec![source_file.to_string_lossy().to_string()];
+        manifest.ai.claude = Some(ClaudeAIConfig {
+            target: target_file.to_string_lossy().to_string(),
+            rules_dir: dir.path().join("rules").to_string_lossy().to_string(),
+        });
+
+        let mut generated_paths = Vec::new();
+        sync_ai_rules(&manifest, &mut generated_paths)?;
+
+        let content1 = fs::read_to_string(&target_file)?;
+        assert!(content1.contains("Source rule content"));
+        assert!(content1.contains("# Manual Title"));
+
+        // Second run with updated source
+        fs::write(&source_file, "Updated source rule content")?;
+        sync_ai_rules(&manifest, &mut generated_paths)?;
+
+        let content2 = fs::read_to_string(&target_file)?;
+        assert!(content2.contains("Updated source rule content"));
+        assert!(!content2.contains("Source rule content"));
+        assert!(content2.contains("# Manual Title"));
+
+        Ok(())
+    }
+}

--- a/src/commands/generate/mod.rs
+++ b/src/commands/generate/mod.rs
@@ -7,6 +7,7 @@ use crate::manifest::{MANIFEST_FILE, Manifest};
 use crate::ownership::{Ownership, get_ownership};
 use crate::templates::TemplateEngine;
 
+mod ai_gen;
 mod catalog;
 mod compose_gen;
 pub(crate) mod registry;
@@ -119,6 +120,9 @@ pub fn sync_from_manifest(manifest: &Manifest) -> Result<()> {
             generated_paths.extend(["tsconfig.base.json".into(), "tsconfig.json".into()]);
         }
     }
+
+    // Generate AI instructions (Issue #203)
+    ai_gen::sync_ai_rules(manifest, &mut generated_paths)?;
 
     // Clean up orphaned files that are no longer being generated (e.g. package.json, hooks)
     crate::commands::clean::remove_orphaned_files(&previous_paths, &generated_paths, false);

--- a/src/commands/guards/scripts.rs
+++ b/src/commands/guards/scripts.rs
@@ -83,10 +83,10 @@ fi
 
 # 2. Airis Context detection & Smart Proxy
 if find_airis_context >/dev/null; then
-    # We are in an airis project or docker-first directory. Route through airis exec
-    # in the workspace service. Phase 1 will replace this with cmd→service auto-routing.
+    # We are in an airis project. `airis exec <cmd>` auto-routes by command
+    # name (Phase 1b): pnpm/npm/node→workspace, python/uv→workspace, cargo→workspace.
     if command -v airis &>/dev/null; then
-        exec airis exec workspace {cmd} "$@"
+        exec airis exec {cmd} "$@"
     else
         echo "⚠️  Airis context detected but 'airis' command not found." >&2
     fi

--- a/src/commands/guards/tests.rs
+++ b/src/commands/guards/tests.rs
@@ -46,14 +46,22 @@ fn test_global_config_serialization() {
 }
 
 #[test]
-fn installed_shim_invokes_airis_exec_workspace() {
+fn installed_shim_invokes_airis_exec_with_cmd_only() {
+    // Phase 1b contract: shim hands off to `airis exec <cmd>` and lets the
+    // CLI auto-route to the right service based on the command's runtime
+    // family. The earlier Phase 0 form `airis exec workspace <cmd>` worked
+    // around the broken CLI signature; now that's no longer needed.
     let dir = tempfile::tempdir().unwrap();
     install_global_guard(dir.path(), "pnpm", GuardLevel::Enforce).unwrap();
 
     let content = fs::read_to_string(dir.path().join("pnpm")).unwrap();
     assert!(
-        content.contains("exec airis exec workspace pnpm \"$@\""),
-        "shim must route through workspace service (Phase 0 contract). Got:\n{content}"
+        content.contains("exec airis exec pnpm \"$@\""),
+        "shim must hand off to `airis exec <cmd>` for auto-routing. Got:\n{content}"
+    );
+    assert!(
+        !content.contains("exec airis exec workspace"),
+        "Phase 0 workaround must be gone now that auto-routing exists. Got:\n{content}"
     );
 }
 

--- a/src/commands/run/exec.rs
+++ b/src/commands/run/exec.rs
@@ -1,0 +1,389 @@
+//! `airis exec` — run a command inside a workspace service container.
+//!
+//! Phase 1b features:
+//! - `airis exec pnpm i` — service is auto-resolved from the cmd's runtime family.
+//! - `airis exec --service web cargo build` — explicit service override.
+//! - `airis exec workspace pnpm i` — backward-compat: a positional first
+//!   argument that matches a known service name still works as a service hint.
+//! - Container auto-up when the resolved service is stopped, suppressed by
+//!   `AIRIS_NO_AUTO_UP=1` or a recent `airis down` marker.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result, bail};
+use colored::Colorize;
+
+use crate::manifest::Manifest;
+
+/// Suppression window after `airis down` during which auto-up is skipped,
+/// so back-to-back `airis down && airis exec ls` does not silently relaunch
+/// the stack the user just intentionally tore down.
+const DOWN_MARKER_TTL: Duration = Duration::from_secs(30);
+
+/// Default service to fall back to when the manifest does not name one
+/// for the resolved runtime family.
+const DEFAULT_SERVICE: &str = "workspace";
+
+/// Runtime family for a command-line invocation. Drives cmd→service routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeFamily {
+    Node,
+    Python,
+    Rust,
+}
+
+/// Map a leading argv token to its runtime family.
+///
+/// Returns None for commands not owned by a known runtime — caller decides
+/// whether to error out or treat the token as a service name.
+pub fn classify_cmd(head: &str) -> Option<RuntimeFamily> {
+    // Strip an optional path prefix so `/usr/bin/python3` and `python3` both classify.
+    let bare = Path::new(head)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(head);
+
+    match bare {
+        "node" | "npm" | "pnpm" | "yarn" | "bun" | "npx" | "tsx" | "tsc" | "next" | "vite"
+        | "tsup" | "deno" => Some(RuntimeFamily::Node),
+        "python" | "python3" | "pip" | "pip3" | "uv" | "poetry" | "ruff" | "mypy" | "pytest"
+        | "ipython" => Some(RuntimeFamily::Python),
+        "cargo" | "rustc" | "rustup" | "clippy-driver" | "rustfmt" => Some(RuntimeFamily::Rust),
+        _ => None,
+    }
+}
+
+/// Entry point for `airis exec`.
+///
+/// `service`: explicit `--service` value (None means auto-resolve).
+/// `cmd`: the command and its args; if `service` is None and `cmd[0]` matches a
+///        known service name in compose, that is interpreted as a positional
+///        service hint to preserve `airis exec workspace ls` behaviour.
+/// `auto_up`: run `airis up` first if the resolved service is not running.
+pub fn run_exec(service: Option<&str>, cmd: &[String], auto_up: bool) -> Result<()> {
+    if cmd.is_empty() {
+        bail!("airis exec: missing command. Usage: airis exec [--service NAME] CMD [ARGS...]");
+    }
+
+    let manifest = Manifest::load_loose(Path::new(crate::manifest::MANIFEST_FILE)).ok();
+
+    let (resolved_service, effective_cmd) = resolve(service, cmd, manifest.as_ref())?;
+
+    let auto_up_disabled =
+        std::env::var_os("AIRIS_NO_AUTO_UP").is_some() || down_marker_recent(manifest.as_ref());
+
+    if auto_up && !auto_up_disabled && !is_service_running(&resolved_service) {
+        eprintln!(
+            "{}  Container '{}' not running, starting via 'airis up'…",
+            "ℹ️ ".cyan(),
+            resolved_service
+        );
+        super::run("up", &[])?;
+    }
+
+    docker_compose_exec(&resolved_service, &effective_cmd)
+}
+
+/// Decide which service to target and which arg slice is the actual command.
+///
+/// Resolution order:
+/// 1. `--service` flag → explicit, pass cmd through unchanged.
+/// 2. cmd[0] matches a manifest-defined service name → positional service
+///    (legacy form, drop cmd[0] from the command).
+/// 3. cmd[0] classifies into a runtime family → look up the service for that
+///    family in the manifest; default to `workspace`.
+/// 4. Otherwise → error with a hint.
+fn resolve<'a>(
+    service: Option<&'a str>,
+    cmd: &'a [String],
+    manifest: Option<&Manifest>,
+) -> Result<(String, Vec<String>)> {
+    if let Some(svc) = service {
+        return Ok((svc.to_string(), cmd.to_vec()));
+    }
+
+    let head = &cmd[0];
+    let known_services = collect_service_names(manifest);
+
+    // Legacy positional service form: `airis exec workspace pnpm install`.
+    // Only triggers when the head is *not* a runtime command — otherwise a user
+    // running a tool whose name happens to match a service would lose their first arg.
+    if classify_cmd(head).is_none() && known_services.iter().any(|s| s == head) && cmd.len() >= 2 {
+        let rest = cmd[1..].to_vec();
+        return Ok((head.clone(), rest));
+    }
+
+    if let Some(family) = classify_cmd(head) {
+        let svc = service_for_family(family, manifest);
+        return Ok((svc, cmd.to_vec()));
+    }
+
+    bail!(
+        "airis exec: cannot resolve service for '{}'.\n\
+         Pass --service NAME explicitly, or use a known runtime command \
+         (node/pnpm/python/cargo/...).",
+        head
+    );
+}
+
+/// Service name to use for a runtime family.
+///
+/// Phase 1b ships a flat default: every family routes to `workspace`. Phase 1.5
+/// (or a follow-up that splits the workspace image per runtime) can derive this
+/// from manifest `[runtimes.<family>].service` once that knob exists.
+fn service_for_family(_family: RuntimeFamily, _manifest: Option<&Manifest>) -> String {
+    DEFAULT_SERVICE.to_string()
+}
+
+/// All service names declared in the manifest (services + apps), plus the
+/// implicit `workspace` default which is always recognized for the legacy
+/// `airis exec workspace <cmd>` form even when no manifest is present.
+fn collect_service_names(manifest: Option<&Manifest>) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    if let Some(m) = manifest {
+        for k in m.service.keys() {
+            names.push(k.clone());
+        }
+        for k in m.apps.keys() {
+            names.push(k.clone());
+        }
+    }
+    if !names.iter().any(|s| s == DEFAULT_SERVICE) {
+        names.push(DEFAULT_SERVICE.to_string());
+    }
+    names
+}
+
+/// `docker compose ps --services --filter status=running` and check membership.
+fn is_service_running(service: &str) -> bool {
+    let Ok(output) = Command::new("docker")
+        .args(["compose", "ps", "--services", "--filter", "status=running"])
+        .output()
+    else {
+        // No docker, no compose, no signal — assume not running and let the
+        // subsequent compose exec / up surface the real error to the user.
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .any(|l| l.trim() == service)
+}
+
+fn docker_compose_exec(service: &str, cmd: &[String]) -> Result<()> {
+    let mut args: Vec<&str> = vec!["compose", "exec", service];
+    for c in cmd {
+        args.push(c);
+    }
+    let mut child = Command::new("docker")
+        .args(&args)
+        .spawn()
+        .with_context(|| "Failed to run docker compose exec")?;
+    let status = child.wait()?;
+    if !status.success() {
+        bail!(
+            "docker compose exec {} {} exited with {:?}",
+            service,
+            cmd.join(" "),
+            status.code()
+        );
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Down-marker — written by `airis down`, read here to suppress auto-up.
+// ============================================================================
+
+/// Path to the down-marker file for this manifest's project, if a project_id
+/// can be derived. Returns None when there is no manifest or no home dir.
+fn down_marker_path(manifest: Option<&Manifest>) -> Option<PathBuf> {
+    let project_id = manifest
+        .map(|m| m.project.id.clone())
+        .filter(|id| !id.is_empty())?;
+    let home = dirs::home_dir()?;
+    Some(
+        home.join(".airis")
+            .join("state")
+            .join(project_id)
+            .join("down-marker"),
+    )
+}
+
+fn down_marker_recent(manifest: Option<&Manifest>) -> bool {
+    let Some(path) = down_marker_path(manifest) else {
+        return false;
+    };
+    let Ok(meta) = std::fs::metadata(&path) else {
+        return false;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    let Ok(elapsed) = SystemTime::now().duration_since(modified) else {
+        return false;
+    };
+    elapsed < DOWN_MARKER_TTL
+}
+
+/// Write the down-marker. Called by `airis down`. Best-effort: failures are
+/// silently ignored — auto-up suppression is a convenience, not a guarantee.
+pub fn write_down_marker(manifest: Option<&Manifest>) {
+    let Some(path) = down_marker_path(manifest) else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, b"");
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{AppConfig, Manifest, MetaSection, ServiceConfig};
+
+    fn manifest_with(project_id: &str, services: &[&str], apps: &[&str]) -> Manifest {
+        let mut m = Manifest::default_with_project(project_id);
+        m.service.clear();
+        for s in services {
+            m.service.insert((*s).to_string(), ServiceConfig::default());
+        }
+        m.apps.clear();
+        for a in apps {
+            m.apps.insert((*a).to_string(), AppConfig::default());
+        }
+        m
+    }
+
+    #[test]
+    fn classify_routes_node_python_rust() {
+        assert_eq!(classify_cmd("pnpm"), Some(RuntimeFamily::Node));
+        assert_eq!(classify_cmd("npx"), Some(RuntimeFamily::Node));
+        assert_eq!(classify_cmd("python3"), Some(RuntimeFamily::Python));
+        assert_eq!(classify_cmd("uv"), Some(RuntimeFamily::Python));
+        assert_eq!(classify_cmd("cargo"), Some(RuntimeFamily::Rust));
+        assert_eq!(classify_cmd("rustfmt"), Some(RuntimeFamily::Rust));
+        assert_eq!(classify_cmd("ls"), None);
+    }
+
+    #[test]
+    fn classify_strips_path_prefix() {
+        assert_eq!(
+            classify_cmd("/usr/bin/python3"),
+            Some(RuntimeFamily::Python)
+        );
+        assert_eq!(
+            classify_cmd("/opt/homebrew/bin/pnpm"),
+            Some(RuntimeFamily::Node)
+        );
+    }
+
+    #[test]
+    fn resolve_explicit_service_passes_cmd_through() {
+        let cmd = vec!["ls".to_string(), "-la".to_string()];
+        let (svc, out) = resolve(Some("api"), &cmd, None).unwrap();
+        assert_eq!(svc, "api");
+        assert_eq!(out, cmd);
+    }
+
+    #[test]
+    fn resolve_runtime_command_routes_to_default() {
+        let cmd = vec!["pnpm".to_string(), "install".to_string()];
+        let (svc, out) = resolve(None, &cmd, None).unwrap();
+        assert_eq!(svc, DEFAULT_SERVICE);
+        assert_eq!(out, cmd);
+    }
+
+    #[test]
+    fn resolve_legacy_positional_service_strips_first_arg() {
+        let m = manifest_with("test", &["api"], &[]);
+        let cmd = vec!["api".to_string(), "ls".to_string()];
+        let (svc, out) = resolve(None, &cmd, Some(&m)).unwrap();
+        assert_eq!(svc, "api");
+        assert_eq!(out, vec!["ls".to_string()]);
+    }
+
+    #[test]
+    fn resolve_workspace_positional_form_still_works() {
+        let cmd = vec!["workspace".to_string(), "pnpm".to_string(), "i".to_string()];
+        // "workspace" is in the implicit known-services list even without a manifest.
+        let (svc, out) = resolve(None, &cmd, None).unwrap();
+        assert_eq!(svc, DEFAULT_SERVICE);
+        assert_eq!(out, vec!["pnpm".to_string(), "i".to_string()]);
+    }
+
+    #[test]
+    fn resolve_runtime_command_does_not_get_swallowed_by_service_lookup() {
+        // "pnpm" must classify as Node and route, even if the user has a
+        // service literally named "pnpm" in their manifest.
+        let mut m = Manifest::default_with_project("test");
+        m.service
+            .insert("pnpm".to_string(), ServiceConfig::default());
+        let cmd = vec!["pnpm".to_string(), "i".to_string()];
+        let (svc, out) = resolve(None, &cmd, Some(&m)).unwrap();
+        assert_eq!(svc, DEFAULT_SERVICE);
+        assert_eq!(out, cmd);
+    }
+
+    #[test]
+    fn resolve_unknown_command_errors_with_hint() {
+        let cmd = vec!["totallymadeup".to_string()];
+        let err = resolve(None, &cmd, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("totallymadeup"), "got: {msg}");
+        assert!(msg.contains("--service"), "got: {msg}");
+    }
+
+    #[test]
+    fn collect_service_names_includes_workspace_default() {
+        let names = collect_service_names(None);
+        assert!(names.contains(&DEFAULT_SERVICE.to_string()));
+    }
+
+    #[test]
+    fn down_marker_path_requires_project_id_and_home() {
+        // No manifest → no path.
+        assert!(down_marker_path(None).is_none());
+
+        // Manifest with empty project.id → no path.
+        let mut m = Manifest::default_with_project("");
+        m.project = MetaSection::default();
+        assert!(down_marker_path(Some(&m)).is_none());
+
+        // Manifest with project id → path under HOME/.airis/state/<id>/down-marker.
+        let m = Manifest::default_with_project("demo");
+        let p = down_marker_path(Some(&m)).expect("path expected when home + project id present");
+        assert!(p.ends_with("down-marker"));
+        assert!(p.to_string_lossy().contains("demo"));
+        assert!(p.to_string_lossy().contains(".airis"));
+    }
+
+    #[test]
+    fn down_marker_recent_respects_ttl() {
+        let m = Manifest::default_with_project("ttltest");
+
+        // Drop any pre-existing marker so this test is deterministic regardless
+        // of whether someone ran `airis down` on this host.
+        if let Some(p) = down_marker_path(Some(&m)) {
+            let _ = std::fs::remove_file(&p);
+        }
+        assert!(!down_marker_recent(Some(&m)));
+
+        write_down_marker(Some(&m));
+        assert!(down_marker_recent(Some(&m)));
+
+        // Cleanup so we don't pollute the user's home dir.
+        if let Some(p) = down_marker_path(Some(&m)) {
+            let _ = std::fs::remove_file(&p);
+        }
+    }
+}

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -1,5 +1,6 @@
 mod build_ops;
 pub(crate) mod compose;
+pub(crate) mod exec;
 mod hooks;
 mod monitoring;
 mod services;
@@ -24,7 +25,17 @@ use services::{display_compose_urls, display_service_urls};
 
 // Re-export public API
 pub use build_ops::{run_build_prod, run_build_quick, run_test_coverage};
-pub use monitoring::{run_exec, run_logs, run_ps, run_restart};
+pub use exec::run_exec;
+pub use monitoring::{run_logs, run_ps, run_restart};
+
+/// Wrapper for `airis down` that drops a down-marker before stopping
+/// containers, so a racing `airis exec` in another shell skips its
+/// auto-up rather than relaunching the stack the user just tore down.
+pub fn run_down(extra_args: &[String]) -> Result<()> {
+    let manifest = Manifest::load_loose(Path::new(crate::manifest::MANIFEST_FILE)).ok();
+    exec::write_down_marker(manifest.as_ref());
+    run("down", extra_args)
+}
 
 // Internal timing constants for health probes
 const TCP_CONNECT_TIMEOUT_MS: u64 = 200;

--- a/src/commands/run/monitoring.rs
+++ b/src/commands/run/monitoring.rs
@@ -120,20 +120,6 @@ pub fn run_logs(service: Option<&str>, follow: bool, tail: Option<u32>) -> Resul
     Ok(())
 }
 
-pub fn run_exec(service: &str, cmd: &[String]) -> Result<()> {
-    let mut args = vec!["compose", "exec", service];
-    for c in cmd {
-        args.push(c);
-    }
-
-    let mut child = Command::new("docker")
-        .args(args)
-        .spawn()
-        .with_context(|| "Failed to run docker compose exec")?;
-    child.wait()?;
-    Ok(())
-}
-
 pub fn run_restart(service: Option<&str>) -> Result<()> {
     let mut args = vec!["compose", "restart"];
     if let Some(s) = service {

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ fn dispatch(command: Commands) -> Result<()> {
         Commands::Run { task, extra_args } => commands::run::run(&task, &extra_args)?,
         Commands::Up { extra_args } => commands::run::run("up", &extra_args)?,
         Commands::Install { extra_args } => commands::install::run(&extra_args)?,
-        Commands::Down { extra_args } => commands::run::run("down", &extra_args)?,
+        Commands::Down { extra_args } => commands::run::run_down(&extra_args)?,
         Commands::Shell { extra_args } => commands::run::run("shell", &extra_args)?,
         Commands::Test {
             scan,
@@ -290,7 +290,11 @@ fn dispatch(command: Commands) -> Result<()> {
             follow,
             tail,
         } => commands::run::run_logs(service.as_deref(), follow, tail)?,
-        Commands::Exec { service, cmd } => commands::run::run_exec(&service, &cmd)?,
+        Commands::Exec {
+            service,
+            no_auto_up,
+            cmd,
+        } => commands::run::run_exec(service.as_deref(), &cmd, !no_auto_up)?,
         Commands::Restart { service } => commands::run::run_restart(service.as_deref())?,
         Commands::Network { action } => match action {
             NetworkCommands::Init => commands::network::init()?,

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -580,6 +580,7 @@ impl Manifest {
                 source: "1.0.0".to_string(),
             },
             docs: DocsSection::default(),
+            ai: AISection::default(),
             ci: CiSection::default(),
             templates: TemplatesSection::default(),
             runtimes: RuntimesSection::default(),

--- a/src/manifest/schema.rs
+++ b/src/manifest/schema.rs
@@ -64,6 +64,9 @@ pub struct Manifest {
     /// Documentation management (CLAUDE.md, .cursorrules, etc.)
     #[serde(default)]
     pub docs: DocsSection,
+    /// AI tool configuration (CLAUDE.md, etc.) SSOT
+    #[serde(default)]
+    pub ai: AISection,
     /// CI/CD configuration
     #[serde(default)]
     pub ci: CiSection,
@@ -1447,6 +1450,53 @@ pub enum DocsVendor {
     Codex,
     Claude,
     Gemini,
+}
+
+/// AI tool configuration — Single Source of Truth for AI rules.
+/// Feeds into CLAUDE.md, AGENTS.md, GEMINI.md, and .cursor/rules/ generation.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct AISection {
+    /// Shared rule files used as the source of truth (e.g., ["docs/ai/PROJECT_RULES.md"])
+    #[serde(default)]
+    pub shared_rules: Vec<String>,
+    /// Claude Code configuration
+    #[serde(default)]
+    pub claude: Option<ClaudeAIConfig>,
+    /// Codex configuration
+    #[serde(default)]
+    pub codex: Option<CodexAIConfig>,
+    /// Gemini configuration
+    #[serde(default)]
+    pub gemini: Option<GeminiAIConfig>,
+    /// Cursor configuration
+    #[serde(default)]
+    pub cursor: Option<CursorAIConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct ClaudeAIConfig {
+    /// Target file path (e.g., ".claude/CLAUDE.md")
+    pub target: String,
+    /// Directory for generated individual rules (e.g., ".claude/rules/generated/")
+    pub rules_dir: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct CodexAIConfig {
+    /// Target file path (e.g., "AGENTS.md")
+    pub target: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct GeminiAIConfig {
+    /// Target file path (e.g., "GEMINI.md")
+    pub target: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct CursorAIConfig {
+    /// Directory for generated individual rules (e.g., ".cursor/rules/")
+    pub rules_dir: String,
 }
 
 /// CI/CD configuration


### PR DESCRIPTION
## Summary

Phase 1b of the [guards & Docker-first re-design plan](https://github.com/agiletec-inc/airis-workspace/blob/main/docs/ai/IDEAL_STATE.md). \`airis exec <cmd>\` now resolves the target service from the command's runtime family instead of demanding a service name as the first positional argument.

This was the missing piece behind the Phase 0 guard-shim workaround (#204), which had to hard-code \`airis exec workspace <cmd>\` because the CLI signature required a positional service. With auto-routing in place, the guard shim reverts to \`exec airis exec {cmd}\` and trusts the CLI to figure out the right container.

## What changes for users

| Invocation | Behaviour |
|---|---|
| \`airis exec pnpm install\` | auto-routes to workspace |
| \`airis exec python -V\` | auto-routes to workspace |
| \`airis exec cargo build\` | auto-routes to workspace |
| \`airis exec --service web ls\` | explicit override (new flag) |
| \`airis exec workspace pnpm install\` | legacy positional form still works |
| \`airis exec --no-auto-up ls\` | skip the auto-up branch |
| \`AIRIS_NO_AUTO_UP=1 airis exec ...\` | env-level opt-out |

When the resolved service is not running, \`airis exec\` runs \`airis up\` first, then proceeds. To avoid trampling an intentional teardown, \`airis down\` writes a marker at \`~/.airis/state/<project_id>/down-marker\` and \`airis exec\` skips auto-up while the marker is younger than 30 seconds.

## Implementation

- **New** \`src/commands/run/exec.rs\` owns the routing table (\`RuntimeFamily\` — Node/Python/Rust), the resolve function, the down-marker, and the \`docker compose exec\` invocation.
- **Removed** the old 12-line \`monitoring::run_exec\` (no resolution, no auto-up). \`run/mod.rs\` re-exports the new entry point.
- **CLI** \`Exec\` becomes \`service: Option<String>\` + \`--no-auto-up\` + \`cmd: Vec<String>\`. Resolve order: \`--service\` flag → legacy positional service hint (only when the head is *not* a runtime command) → cmd→family→service.
- **Runtime commands always classify**, so a user with a service literally named \`pnpm\` won't accidentally lose their first arg.
- **\`main.rs\` Down** branch now wraps via \`commands::run::run_down\`, which drops the marker before tearing down so a racing \`airis exec\` in another shell observes it.
- **Guard shim** (\`scripts.rs:88\`) reverts the Phase 0 workaround to \`exec airis exec {cmd} \"\$@\"\`. The Phase 0 test assertion is updated to require both the new form and the absence of the old workaround.

## Phase boundaries

Phase 1b ships routing + auto-up but **does not yet provision new runtimes inside the workspace image**. Today's workspace image is still Node 24 + pnpm only (\`channel.rs:113\`); \`airis exec python\` will route correctly but the container itself does not yet have a Python interpreter. Phase 1c lands the multi-runtime workspace Dockerfile (Node + Python + Rust + uv + rustup in one image).

## Test plan

- [x] \`cargo test --lib\` 340 pass (11 new in \`commands::run::exec::tests\`)
- [x] \`cargo test --tests\` 20 pass
- [x] \`cargo test --doc\` clean (rewrote \`Exec\` doc example as text block)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -D warnings\` clean
- [x] \`airis test\` clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)