### PR TITLE
feat(guards): add AIRIS_BYPASS and `airis host` for easy guard bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.14.2"
+version = "3.14.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.14.2"
+version = "3.14.3"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,20 @@ pub enum Commands {
         action: GuardsCommands,
     },
 
+    /// Run a host command, bypassing airis guards (sets AIRIS_BYPASS=1)
+    ///
+    /// Use this when you need to run a guarded command (pnpm, npm, python, ...)
+    /// directly on the host — e.g. global installs outside any airis workspace.
+    ///
+    /// Examples:
+    ///   airis host npm install -g typescript
+    ///   airis host pnpm add -g prettier
+    Host {
+        /// Command and arguments to run on the host.
+        #[arg(trailing_var_arg = true, required = true, allow_hyphen_values = true)]
+        cmd: Vec<String>,
+    },
+
     /// Project-level cleanup and management
     Workspace(WorkspaceArgs),
 

--- a/src/commands/guards/scripts.rs
+++ b/src/commands/guards/scripts.rs
@@ -76,6 +76,11 @@ find_airis_context() {{
 
 REAL_CMD=$(find_real_cmd {cmd})
 
+# 0. Explicit bypass: AIRIS_BYPASS=1 or `airis host <cmd>`
+if [[ "${{AIRIS_BYPASS:-}}" == "1" ]]; then
+    if [[ -n "$REAL_CMD" ]]; then exec "$REAL_CMD" "$@"; else exit 127; fi
+fi
+
 # 1. Inside Docker/CI: always allow host command
 if [[ -f /.dockerenv ]] || grep -qsE 'docker|containerd' /proc/1/cgroup 2>/dev/null || [[ "${{DOCKER_CONTAINER:-}}" == "true" ]] || [[ "${{CI:-}}" == "true" ]]; then
     if [[ -n "$REAL_CMD" ]]; then exec "$REAL_CMD" "$@"; else exit 127; fi

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -1,0 +1,30 @@
+use anyhow::{Result, bail};
+use std::env;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+/// Run a host command bypassing airis guards (`AIRIS_BYPASS=1`).
+pub fn run(cmd: &[String]) -> Result<()> {
+    let (name, args) = cmd.split_first().expect("cmd is non-empty (enforced by clap)");
+
+    // Find the real binary, excluding ~/.airis/bin so we don't re-enter the guard.
+    let real_path = env::var("PATH")
+        .unwrap_or_default()
+        .split(':')
+        .filter(|p| !p.contains(".airis/bin"))
+        .find_map(|p| {
+            let candidate = std::path::Path::new(p).join(name);
+            candidate.is_file().then_some(candidate)
+        });
+
+    let Some(binary) = real_path else {
+        bail!("'{}' not found on host PATH (excluding ~/.airis/bin)", name);
+    };
+
+    let err = Command::new(&binary)
+        .args(args)
+        .env("AIRIS_BYPASS", "1")
+        .exec();
+
+    bail!("failed to exec {}: {}", binary.display(), err);
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod generate;
 pub mod generate_types;
 pub mod guards;
 pub mod hooks;
+pub mod host;
 pub mod init_shell;
 pub mod install;
 pub mod manifest_cmd;

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,7 @@ fn dispatch(command: Commands) -> Result<()> {
                 println!("check-allow is now handled by global smart-shims.");
             }
         },
+        Commands::Host { cmd } => commands::host::run(&cmd)?,
         Commands::Workspace(args) => match args.action {
             WorkspaceCommands::Uninstall => commands::workspace::uninstall()?,
         },


### PR DESCRIPTION
## Summary

- Guard scripts now short-circuit on `AIRIS_BYPASS=1` before any routing logic
- `airis host <cmd> [args...]` runs a guarded command directly on the host by finding the real binary (skipping `~/.airis/bin`) and exec-ing it with `AIRIS_BYPASS=1`

## Usage

```bash
# Global npm/pnpm installs outside any workspace
airis host npm install -g typescript
airis host pnpm add -g prettier

# Or set the env var yourself for one-off use
AIRIS_BYPASS=1 npm install -g something
```

## Test plan

- [ ] `airis host echo hello` prints `hello`
- [ ] `airis host --help` shows usage with examples
- [ ] Inside an airis workspace, `AIRIS_BYPASS=1 pnpm --version` runs on the host instead of routing to Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)