### PR TITLE
fix(guards): only enforce Docker routing inside an airis workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.14.3"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.15.0"
+version = "3.15.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.15.0"
+version = "3.15.1"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.14.3"
+version = "3.15.0"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/guards/global.rs
+++ b/src/commands/guards/global.rs
@@ -57,7 +57,11 @@ fn setup_shell_path() -> Result<()> {
         }
 
         let content = fs::read_to_string(&rc_path)?;
-        let shell_name = if rc_file.contains("zsh") { "zsh" } else { "bash" };
+        let shell_name = if rc_file.contains("zsh") {
+            "zsh"
+        } else {
+            "bash"
+        };
 
         let mut lines_to_add: Vec<String> = Vec::new();
 
@@ -70,15 +74,21 @@ fn setup_shell_path() -> Result<()> {
         // 2. Prompt integration setup
         if !content.contains("airis init-shell") {
             use dialoguer::{Confirm, theme::ColorfulTheme};
-            let question = format!("Would you like to enable the airis status line in your {} prompt?", shell_name);
-            
+            let question = format!(
+                "Would you like to enable the airis status line in your {} prompt?",
+                shell_name
+            );
+
             if Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt(question)
                 .default(true)
                 .interact()
-                .unwrap_or(false) 
+                .unwrap_or(false)
             {
-                lines_to_add.push(format!("source <(airis init-shell {}) # airis prompt", shell_name));
+                lines_to_add.push(format!(
+                    "source <(airis init-shell {}) # airis prompt",
+                    shell_name
+                ));
                 prompt_added = true;
             }
         }

--- a/src/commands/guards/scripts.rs
+++ b/src/commands/guards/scripts.rs
@@ -111,21 +111,9 @@ if find_airis_context >/dev/null; then
     fi
 fi
 
-# 3. Not in airis workspace or airis missing: Apply Policy
-case "$LEVEL" in
-    warn)
-        echo "⚠️  AIRIS: '{cmd}' is being run on the host. Consider using 'airis exec' or 'airis shell'." >&2
-        if [[ -n "$REAL_CMD" ]]; then exec "$REAL_CMD" "$@"; else exit 127; fi
-        ;;
-    enforce)
-        echo "❌ AIRIS: '{cmd}' is enforced. No airis project context found." >&2
-        echo "   cd into a workspace with manifest.toml/compose.yaml, or set guards.preset = warn." >&2
-        exit 126
-        ;;
-    *)
-        if [[ -n "$REAL_CMD" ]]; then exec "$REAL_CMD" "$@"; else exit 127; fi
-        ;;
-esac
+# 3. Not in any airis workspace — pass through unconditionally.
+#    Guards only enforce Docker-first hygiene *inside* a workspace.
+if [[ -n "$REAL_CMD" ]]; then exec "$REAL_CMD" "$@"; else exit 127; fi
 "#,
         GLOBAL_GUARD_MARKER = GLOBAL_GUARD_MARKER,
         level = level_str,

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -5,7 +5,9 @@ use std::process::Command;
 
 /// Run a host command bypassing airis guards (`AIRIS_BYPASS=1`).
 pub fn run(cmd: &[String]) -> Result<()> {
-    let (name, args) = cmd.split_first().expect("cmd is non-empty (enforced by clap)");
+    let (name, args) = cmd
+        .split_first()
+        .expect("cmd is non-empty (enforced by clap)");
 
     // Find the real binary, excluding ~/.airis/bin so we don't re-enter the guard.
     let real_path = env::var("PATH")

--- a/src/commands/init_shell.rs
+++ b/src/commands/init_shell.rs
@@ -3,7 +3,8 @@ use anyhow::Result;
 pub fn run(shell: clap_complete::Shell) -> Result<()> {
     match shell {
         clap_complete::Shell::Zsh => {
-            println!(r#"
+            println!(
+                r#"
 # airis shell integration (zsh)
 # Add this to your ~/.zshrc: source <(airis init-shell zsh)
 
@@ -20,10 +21,12 @@ _airis_prompt_precmd() {{
 # Add to precmd hooks
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd _airis_prompt_precmd
-"#);
+"#
+            );
         }
         clap_complete::Shell::Bash => {
-            println!(r#"
+            println!(
+                r#"
 # airis shell integration (bash)
 # Add this to your ~/.bashrc: source <(airis init-shell bash)
 
@@ -34,7 +37,8 @@ _airis_prompt_command() {{
 }}
 
 # PROMPT_COMMAND="...; _airis_prompt_command"
-"#);
+"#
+            );
         }
         _ => {
             eprintln!("Shell integration not yet implemented for {:?}", shell);

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,7 +1,7 @@
+use crate::manifest::{GlobalConfig, MANIFEST_FILE, Manifest};
 use anyhow::Result;
 use colored::Colorize;
 use std::path::Path;
-use crate::manifest::{Manifest, MANIFEST_FILE, GlobalConfig};
 
 pub fn run(short: bool) -> Result<()> {
     if short {
@@ -16,26 +16,49 @@ pub fn run(short: bool) -> Result<()> {
     let manifest_path = Path::new(MANIFEST_FILE);
     if manifest_path.exists() {
         if let Ok(manifest) = Manifest::load(manifest_path) {
-            println!("{:<15} {}", "Project:".bright_yellow(), manifest.workspace.name.cyan());
+            println!(
+                "{:<15} {}",
+                "Project:".bright_yellow(),
+                manifest.workspace.name.cyan()
+            );
         }
     } else {
         let current_dir = std::env::current_dir()?;
-        let dir_name = current_dir.file_name().unwrap_or_default().to_string_lossy();
-        println!("{:<15} {} (no manifest)", "Directory:".bright_yellow(), dir_name.dimmed());
+        let dir_name = current_dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy();
+        println!(
+            "{:<15} {} (no manifest)",
+            "Directory:".bright_yellow(),
+            dir_name.dimmed()
+        );
     }
 
     // Guards Info
     if let Ok(config) = GlobalConfig::load() {
-        println!("{:<15} {:?}", "Guard Level:".bright_yellow(), config.guards.preset);
+        println!(
+            "{:<15} {:?}",
+            "Guard Level:".bright_yellow(),
+            config.guards.preset
+        );
     }
 
     // Docker Context
-    let has_compose = Path::new("compose.yaml").exists() 
-        || Path::new("compose.yml").exists() 
-        || Path::new("docker-compose.yaml").exists() 
+    let has_compose = Path::new("compose.yaml").exists()
+        || Path::new("compose.yml").exists()
+        || Path::new("docker-compose.yaml").exists()
         || Path::new("docker-compose.yml").exists();
-    
-    println!("{:<15} {}", "Docker context:".bright_yellow(), if has_compose { "✓".green() } else { "✗".red() });
+
+    println!(
+        "{:<15} {}",
+        "Docker context:".bright_yellow(),
+        if has_compose {
+            "✓".green()
+        } else {
+            "✗".red()
+        }
+    );
 
     Ok(())
 }
@@ -44,10 +67,10 @@ fn run_short() -> Result<()> {
     let mut parts = Vec::new();
 
     let manifest_path = Path::new(MANIFEST_FILE);
-    let has_project_context = manifest_path.exists() 
-        || Path::new("compose.yaml").exists() 
-        || Path::new("compose.yml").exists() 
-        || Path::new("docker-compose.yaml").exists() 
+    let has_project_context = manifest_path.exists()
+        || Path::new("compose.yaml").exists()
+        || Path::new("compose.yml").exists()
+        || Path::new("docker-compose.yaml").exists()
         || Path::new("docker-compose.yml").exists();
 
     // 1. Airis Icon
@@ -56,10 +79,16 @@ fn run_short() -> Result<()> {
     if has_project_context {
         // --- Project Context ---
         let name = if manifest_path.exists() {
-            Manifest::load(manifest_path).map(|m| m.workspace.name).unwrap_or_else(|_| "unknown".into())
+            Manifest::load(manifest_path)
+                .map(|m| m.workspace.name)
+                .unwrap_or_else(|_| "unknown".into())
         } else {
             let current_dir = std::env::current_dir()?;
-            current_dir.file_name().unwrap_or_default().to_string_lossy().to_string()
+            current_dir
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string()
         };
 
         // POLLUTION CHECK: check for node_modules, etc. on host
@@ -72,12 +101,16 @@ fn run_short() -> Result<()> {
         }
 
         // Bypass check
-        let bypass = std::env::var("AIRIS_SKIP_GUARD").is_ok() 
+        let bypass = std::env::var("AIRIS_SKIP_GUARD").is_ok()
             || std::env::var("AIRIS_BYPASS").is_ok()
             || std::env::var("AIRIS_HOST").is_ok();
 
         if polluted {
-            parts.push(format!("💀{}({})", name.red().bold(), "POLLUTED".on_red().white().bold()));
+            parts.push(format!(
+                "💀{}({})",
+                name.red().bold(),
+                "POLLUTED".on_red().white().bold()
+            ));
         } else if bypass {
             parts.push(format!("{}({})", name.yellow(), "BYPASS".bold().yellow()));
         } else {
@@ -97,7 +130,7 @@ fn run_short() -> Result<()> {
         };
         parts.push(level_icon.to_string());
     }
-    
+
     print!("{}", parts.join(" "));
     Ok(())
 }

--- a/src/manifest/global_config.rs
+++ b/src/manifest/global_config.rs
@@ -15,7 +15,7 @@ pub enum GuardLevel {
     Off,
     /// Warn the user but proceed with original command
     Warn,
-    /// Warn and block if inside an airis project or specific conditions met
+    /// Force Docker routing inside an airis workspace; pass through outside
     Enforce,
 }
 


### PR DESCRIPTION
## Summary

Guards were blocking guarded commands (e.g. `pnpm`, `npm`) even when run **outside** any airis workspace. This is wrong — the guard's only job is Docker-first hygiene enforcement *inside* a workspace.

**Before:** `enforce` level would block `pnpm` anywhere on the host, even in a directory with no `manifest.toml` or `compose.yaml`.

**After:** Outside an airis workspace, all guarded commands pass through unconditionally. The `enforce`/`warn`/`off` distinction only matters within a workspace context (where `enforce` routes to Docker).

## Behavior matrix

| Location | Before (enforce) | After |
|---|---|---|
| Docker/CI | pass through | pass through |
| airis workspace | route to Docker | route to Docker |
| anywhere else | ❌ block | ✅ pass through |

## Test plan

- [ ] `pnpm --version` in `~` (no workspace) runs on host without error
- [ ] `pnpm install` inside an airis workspace still routes to Docker
- [ ] `AIRIS_BYPASS=1` and `airis host` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)