### PR TITLE
fix(security): catalog validation, security tests, CI audit, dep fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,14 @@ jobs:
             exit 1
           fi
           echo "OK: under limit"
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run cargo audit
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.16.6"
+version = "3.16.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.16.7"
+version = "3.16.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.16.9"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -48,7 +48,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "tempfile",
  "thiserror",
  "tokio",
@@ -318,7 +318,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -504,7 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -863,16 +863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,7 +1205,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1340,18 +1330,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1469,7 +1457,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1661,6 +1649,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -1883,7 +1877,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.17.0"
+version = "3.17.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.16.8"
+version = "3.16.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -318,7 +318,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -504,14 +504,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1215,14 +1215,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1469,7 +1469,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1883,7 +1883,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.16.7"
+version = "3.16.8"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.16.6"
+version = "3.16.7"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.16.9"
+version = "3.17.0"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"
@@ -70,7 +70,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.6", features = ["derive", "cargo", "env"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_yml = "0.0"
+serde_yaml_ng = "0.10"
 toml = { version = "1.1", features = ["preserve_order"] }
 anyhow = "1.0"
 colored = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.17.0"
+version = "3.17.1"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.16.8"
+version = "3.16.9"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/discover/catalog.rs
+++ b/src/commands/discover/catalog.rs
@@ -60,7 +60,7 @@ pub fn extract_catalog_from_path(base_path: &Path) -> Result<IndexMap<String, St
             catalog: Option<IndexMap<String, String>>,
         }
 
-        if let Ok(workspace) = serde_yml::from_str::<PnpmWorkspace>(&content)
+        if let Ok(workspace) = serde_yaml_ng::from_str::<PnpmWorkspace>(&content)
             && let Some(existing_catalog) = workspace.catalog
         {
             for (pkg, version) in existing_catalog {

--- a/src/commands/generate/compose_gen.rs
+++ b/src/commands/generate/compose_gen.rs
@@ -285,7 +285,7 @@ pub fn generate_workspace_compose(manifest: &Manifest) -> Result<()> {
         networks,
     };
 
-    let content = serde_yml::to_string(&compose)?;
+    let content = serde_yaml_ng::to_string(&compose)?;
 
     // Standardize on compose.yaml (Docker Compose V2) at the project root
     let target_path = Path::new("compose.yaml");

--- a/src/commands/run/traefik.rs
+++ b/src/commands/run/traefik.rs
@@ -20,8 +20,8 @@ pub(super) fn parse_traefik_routers(traefik_dir: &str) -> Vec<(String, String, S
 
     let mut results = Vec::new();
 
-    // Parse YAML using serde_yml
-    let yaml: serde_yml::Value = match serde_yml::from_str(&content) {
+    // Parse YAML using serde_yaml_ng
+    let yaml: serde_yaml_ng::Value = match serde_yaml_ng::from_str(&content) {
         Ok(v) => v,
         Err(_) => return Vec::new(),
     };

--- a/src/manifest/tests.rs
+++ b/src/manifest/tests.rs
@@ -1145,3 +1145,69 @@ id = "test"
         "got: {msg}"
     );
 }
+
+#[test]
+fn test_validate_catalog_rejects_query_string() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[packages.catalog]
+"react?version=18" = "latest"
+"#;
+    let err = load_from_str(toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("react?version=18") && msg.contains("valid npm package name"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_catalog_rejects_fragment() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[packages.catalog]
+"react#latest" = "latest"
+"#;
+    let err = load_from_str(toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("react#latest") && msg.contains("valid npm package name"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_guard_wrap_value_with_newline_rejected() {
+    let toml = "version = 1\n[project]\nid = \"test\"\n[guards]\n[guards.wrap]\nnpm = \"docker exec workspace npm\\nrm -rf /\"\n";
+    // Newlines are in the dangerous_chars list — must be rejected.
+    let err = load_from_str(toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("dangerous character"),
+        "newline in wrap value should be rejected; got: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_guard_deny_with_message_invalid_name_rejected() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[guards.deny_with_message]
+"npm; evil" = "do not use npm"
+"#;
+    let err = load_from_str(toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("npm; evil") && msg.contains("invalid command name"),
+        "got: {msg}"
+    );
+}

--- a/src/manifest/tests.rs
+++ b/src/manifest/tests.rs
@@ -1075,3 +1075,73 @@ package_manager = "uv"
         Some("uv")
     );
 }
+
+#[test]
+fn test_validate_catalog_valid_npm_names() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[packages.catalog]
+react = "latest"
+react-dom = "latest"
+"@agiletec/ui" = "latest"
+"@scope/my-pkg.v2" = "latest"
+"#;
+    assert!(load_from_str(toml).is_ok());
+}
+
+#[test]
+fn test_validate_catalog_rejects_path_traversal() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[packages.catalog]
+"../evil" = "latest"
+"#;
+    let err = load_from_str(toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("../evil") && msg.contains("valid npm package name"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_catalog_rejects_uppercase() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[packages.catalog]
+"React" = "latest"
+"#;
+    let err = load_from_str(toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("React") && msg.contains("valid npm package name"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_catalog_rejects_spaces_in_name() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[packages.catalog]
+"bad name" = "latest"
+"#;
+    let err = load_from_str(toml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("bad name") && msg.contains("valid npm package name"),
+        "got: {msg}"
+    );
+}

--- a/src/manifest/validation.rs
+++ b/src/manifest/validation.rs
@@ -7,12 +7,18 @@ use super::*;
 static GUARD_CMD_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"^[a-zA-Z0-9._+\-]+$").expect("guard command regex"));
 
+// https://docs.npmjs.com/cli/v10/configuring-npm/package-json#name
+static NPM_PKG_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"^(@[a-z0-9][a-z0-9\-._~]*/)?[a-z0-9][a-z0-9\-._~]*$")
+        .expect("npm package name regex")
+});
+
 impl Manifest {
     /// Validate manifest consistency.
     ///
     /// Checks:
     /// 1. No duplicate ports across service entries
-    /// 2. Catalog follow references point to existing catalog keys
+    /// 2. Catalog keys are valid npm package names; follow references point to existing catalog keys
     /// 3. No command appears in both guards.deny and guards.wrap
     /// 4. dep_group / env_group references resolve to defined groups
     /// 5. Catalog follow chains have no cycles
@@ -59,7 +65,13 @@ impl Manifest {
         }
 
         // 2. Validate catalog follow references (skip if default_policy can resolve the target)
+        // Also validate catalog keys as npm package names to prevent URL path manipulation.
         for (key, entry) in &self.packages.catalog {
+            if !NPM_PKG_RE.is_match(key) {
+                errors.push(format!(
+                    "packages.catalog key \"{key}\" is not a valid npm package name (use lowercase letters, digits, hyphens, dots; scoped names like @scope/pkg are allowed)"
+                ));
+            }
             if let CatalogEntry::Follow(f) = entry
                 && !self.packages.catalog.contains_key(&f.follow)
                 && self.packages.default_policy.is_none()

--- a/src/pnpm.rs
+++ b/src/pnpm.rs
@@ -54,7 +54,7 @@ impl PnpmLock {
             .with_context(|| format!("Failed to read {}", path.display()))?;
 
         let lock: PnpmLock =
-            serde_yml::from_str(&content).with_context(|| "Failed to parse pnpm-lock.yaml")?;
+            serde_yaml_ng::from_str(&content).with_context(|| "Failed to parse pnpm-lock.yaml")?;
 
         if !lock.lockfile_version.starts_with("9.") {
             anyhow::bail!(
@@ -172,7 +172,7 @@ pub fn read_workspace_catalog() -> IndexMap<String, String> {
     #[derive(serde::Deserialize)]
     struct PnpmWorkspace {
         #[serde(default)]
-        catalog: IndexMap<String, serde_yml::Value>,
+        catalog: IndexMap<String, serde_yaml_ng::Value>,
     }
 
     let content = match std::fs::read_to_string(path) {
@@ -180,7 +180,7 @@ pub fn read_workspace_catalog() -> IndexMap<String, String> {
         Err(_) => return IndexMap::new(),
     };
 
-    let workspace: PnpmWorkspace = match serde_yml::from_str(&content) {
+    let workspace: PnpmWorkspace = match serde_yaml_ng::from_str(&content) {
         Ok(w) => w,
         Err(_) => return IndexMap::new(),
     };

--- a/src/secrets/doppler.rs
+++ b/src/secrets/doppler.rs
@@ -36,3 +36,77 @@ impl SecretProvider for DopplerProvider {
         "doppler"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider() -> DopplerProvider {
+        DopplerProvider {
+            project: "my-project".into(),
+            config: "dev".into(),
+        }
+    }
+
+    #[test]
+    fn wrap_command_uses_doppler_as_program() {
+        let (program, _) = provider().wrap_command("docker", &["compose", "up"]);
+        assert_eq!(program, "doppler");
+    }
+
+    #[test]
+    fn wrap_command_passes_args_as_list_not_shell_string() {
+        // Security property: each element must be a separate list entry.
+        // If args were concatenated into a shell string, a value like
+        // "up; rm -rf /" would execute an injected command.
+        let (_, args) = provider().wrap_command("docker", &["compose", "up; rm -rf /"]);
+        // The injected string must appear verbatim as one element, not split.
+        assert!(
+            args.iter().any(|a| a == "up; rm -rf /"),
+            "argument must be a single list element, not interpreted by a shell"
+        );
+        // No element should be just "rm" or "rf"
+        assert!(!args.iter().any(|a| a == "rm"), "shell must not split args");
+    }
+
+    #[test]
+    fn wrap_command_structure_is_correct() {
+        let (_, args) = provider().wrap_command("docker", &["compose", "up", "-d"]);
+        // Expected: run --project my-project --config dev -- docker compose up -d
+        assert_eq!(args[0], "run");
+        assert_eq!(args[1], "--project");
+        assert_eq!(args[2], "my-project");
+        assert_eq!(args[3], "--config");
+        assert_eq!(args[4], "dev");
+        assert_eq!(args[5], "--");
+        assert_eq!(args[6], "docker");
+        assert_eq!(args[7], "compose");
+        assert_eq!(args[8], "up");
+        assert_eq!(args[9], "-d");
+    }
+
+    #[test]
+    fn wrap_command_with_no_extra_args() {
+        let (program, args) = provider().wrap_command("docker", &[]);
+        assert_eq!(program, "doppler");
+        assert_eq!(args, ["run", "--project", "my-project", "--config", "dev", "--", "docker"]);
+    }
+
+    #[test]
+    fn name_returns_doppler() {
+        assert_eq!(provider().name(), "doppler");
+    }
+
+    #[test]
+    fn project_and_config_values_are_preserved() {
+        let p = DopplerProvider {
+            project: "prod-app".into(),
+            config: "prd".into(),
+        };
+        let (_, args) = p.wrap_command("sh", &[]);
+        let proj_pos = args.iter().position(|a| a == "--project").unwrap();
+        let cfg_pos = args.iter().position(|a| a == "--config").unwrap();
+        assert_eq!(args[proj_pos + 1], "prod-app");
+        assert_eq!(args[cfg_pos + 1], "prd");
+    }
+}

--- a/src/secrets/doppler.rs
+++ b/src/secrets/doppler.rs
@@ -89,7 +89,18 @@ mod tests {
     fn wrap_command_with_no_extra_args() {
         let (program, args) = provider().wrap_command("docker", &[]);
         assert_eq!(program, "doppler");
-        assert_eq!(args, ["run", "--project", "my-project", "--config", "dev", "--", "docker"]);
+        assert_eq!(
+            args,
+            [
+                "run",
+                "--project",
+                "my-project",
+                "--config",
+                "dev",
+                "--",
+                "docker"
+            ]
+        );
     }
 
     #[test]

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -34,3 +34,55 @@ pub fn create_provider(secrets: &SecretsSection) -> Result<Box<dyn SecretProvide
         other => bail!("Unknown secrets provider: '{}'. Supported: doppler", other),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{DopplerSecretsConfig, SecretsSection};
+
+    fn doppler_secrets(project: &str, config: &str) -> SecretsSection {
+        SecretsSection {
+            provider: "doppler".into(),
+            doppler: Some(DopplerSecretsConfig {
+                project: project.into(),
+                config: config.into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn create_provider_doppler_returns_doppler() {
+        let s = doppler_secrets("my-project", "dev");
+        let p = create_provider(&s).unwrap();
+        assert_eq!(p.name(), "doppler");
+    }
+
+    #[test]
+    fn create_provider_unknown_returns_error() {
+        let s = SecretsSection {
+            provider: "vault".into(),
+            doppler: None,
+        };
+        let msg = match create_provider(&s) {
+            Ok(_) => panic!("expected error for unknown provider"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("vault") && msg.contains("Supported"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn create_provider_doppler_missing_section_returns_error() {
+        let s = SecretsSection {
+            provider: "doppler".into(),
+            doppler: None,
+        };
+        let msg = match create_provider(&s) {
+            Ok(_) => panic!("expected error for missing doppler section"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("[secrets.doppler]"), "got: {msg}");
+    }
+}


### PR DESCRIPTION
## Summary

セキュリティ・品質改善を4コミットにまとめたPR。

### #131 — npmパッケージ名バリデーション (fix)
- `packages.catalog` のキーを npm パッケージ名として manifest validation 時に検証
- `../evil`（パストラバーサル）・大文字・スペース・クエリ文字列・フラグメントを拒否

### #132 — セキュリティコードパステスト (test)
- `secrets/doppler.rs`: `wrap_command()` が引数をリストとして渡す（シェル非解釈）ことを検証（6テスト）
- `secrets/mod.rs`: `create_provider()` の未知プロバイダー・設定欠落エラーを検証（3テスト）
- `manifest/tests.rs`: catalog key の adversarial inputs（4テスト）

### #159 — CI dependency auditing + 依存更新 (feat/fix)
- `rustsec/audit-check@v2` を `dependency-audit` ジョブとして追加
- Cargo.lock 更新で CVE 3件を解消: RUSTSEC-2026-0104/0098/0099 (rustls-webpki)
- fastrand 2.4.0 (yanked) → 2.4.1

### serde_yml → serde_yaml_ng 移行 (fix)
- `serde_yml` (RUSTSEC-2025-0067/0068: unsound/unmaintained) を `serde_yaml_ng` に移行
- `cargo audit` が完全クリーン（脆弱性0、警告0）に

Closes #131
Closes #132
Closes #159

## Test plan

- [x] `cargo test` — 365テスト全パス
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo audit` — 脆弱性0、警告0

🤖 Generated with [Claude Code](https://claude.com/claude-code)