### PR TITLE
fix(gen): move workspace compose output to .airis/, treat all compose variants as user-owned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.17.1"
+version = "3.17.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.17.1"
+version = "3.17.2"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/generate/compose_gen.rs
+++ b/src/commands/generate/compose_gen.rs
@@ -287,8 +287,9 @@ pub fn generate_workspace_compose(manifest: &Manifest) -> Result<()> {
 
     let content = serde_yaml_ng::to_string(&compose)?;
 
-    // Standardize on compose.yaml (Docker Compose V2) at the project root
-    let target_path = Path::new("compose.yaml");
+    // Output workspace dev containers to .airis/ so they don't conflict with the
+    // user-owned runtime compose.yaml at the project root.
+    let target_path = Path::new(".airis/workspace-compose.yaml");
     if let Some(parent) = target_path.parent()
         && !parent.as_os_str().is_empty()
     {

--- a/src/commands/generate/mod.rs
+++ b/src/commands/generate/mod.rs
@@ -118,7 +118,7 @@ pub(super) fn write_with_backup(path: &Path, content: &str) -> Result<()> {
 
 pub fn preview_from_manifest(_manifest: &Manifest) -> Result<()> {
     println!("{}", "📋 Files that would be generated:".bright_yellow());
-    println!("   - compose.yaml");
+    println!("   - .airis/workspace-compose.yaml");
     println!("   - tsconfig.json");
     Ok(())
 }
@@ -136,7 +136,7 @@ pub fn sync_from_manifest(manifest: &Manifest) -> Result<()> {
         // Always generate Docker Compose to ensure environment isolation (Hygiene).
         // Convention-based discovery ensures projects are managed even if not in manifest.toml.
         generate_workspace_compose(manifest)?;
-        generated_paths.push("compose.yaml".into());
+        generated_paths.push(".airis/workspace-compose.yaml".into());
 
         // Generate TSConfig paths (Derived from discovery)
         if !manifest.typescript.skip {

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -28,12 +28,13 @@ pub fn get_ownership(path: &Path) -> Ownership {
         "tsconfig.base.json" => Ownership::Tool,
         "airis.lock" => Ownership::Tool,
 
-        // compose.yaml is the canonical Docker Compose V2 name — always Tool-owned.
-        // Legacy variants are User-owned; use `airis gen --force` to migrate them.
-        "compose.yaml" | "workspace/compose.yaml" => Ownership::Tool,
-        "compose.yml"
+        // All compose variants are user-owned: airis gen writes to .airis/workspace-compose.yaml
+        // instead of the project root, so it never conflicts with the user's runtime compose.yaml.
+        "compose.yaml"
+        | "compose.yml"
         | "docker-compose.yaml"
         | "docker-compose.yml"
+        | "workspace/compose.yaml"
         | "workspace/compose.yml"
         | "workspace/docker-compose.yaml"
         | "workspace/docker-compose.yml" => Ownership::User,
@@ -115,7 +116,10 @@ mod tests {
             Ownership::Tool
         );
         assert_eq!(get_ownership(Path::new("airis.lock")), Ownership::Tool);
-        assert_eq!(get_ownership(Path::new("compose.yaml")), Ownership::Tool);
+        assert_eq!(
+            get_ownership(Path::new(".airis/workspace-compose.yaml")),
+            Ownership::Tool
+        );
 
         // App package.json files are now tool-owned
         assert_eq!(
@@ -134,18 +138,14 @@ mod tests {
 
     #[test]
     fn test_compose_yaml_variants_ownership() {
-        // compose.yaml is the Docker Compose V2 canonical name — always Tool-owned (airis manages it).
-        assert_eq!(get_ownership(Path::new("compose.yaml")), Ownership::Tool);
-        assert_eq!(
-            get_ownership(Path::new("workspace/compose.yaml")),
-            Ownership::Tool
-        );
-
-        // Legacy variants are always User-owned — airis never touches them.
+        // All compose variants at the project root are user-owned.
+        // airis gen writes to .airis/workspace-compose.yaml instead.
         for name in &[
+            "compose.yaml",
             "compose.yml",
             "docker-compose.yaml",
             "docker-compose.yml",
+            "workspace/compose.yaml",
             "workspace/compose.yml",
             "workspace/docker-compose.yaml",
             "workspace/docker-compose.yml",
@@ -153,7 +153,7 @@ mod tests {
             assert_eq!(
                 get_ownership(Path::new(name)),
                 Ownership::User,
-                "{name} should be User-owned (legacy)"
+                "{name} should be User-owned"
             );
         }
     }


### PR DESCRIPTION
## Summary
- `airis gen` now writes workspace dev containers to `.airis/workspace-compose.yaml` instead of `compose.yaml` at the project root
- All compose file variants (`compose.yaml`, `compose.yml`, `docker-compose.yml`, etc.) are now `Ownership::User` — airis will never overwrite them
- Fixes the root conflict where Docker's auto-discovery order (`compose.yaml` > `docker-compose.yml`) caused the generated workspace compose to shadow the user's runtime `compose.yaml`

## Motivation
In projects like `airis-mcp-gateway`, `compose.yaml` (or `docker-compose.yml`) is the user-managed runtime compose with all production services (api, gateway, serena, postgres). Previously, `airis gen` would generate its own `compose.yaml` for dev workspace containers, clobbering the user's file because Docker discovers `compose.yaml` first.

## Test plan
- [ ] `cargo test` passes (all 20 tests green)
- [ ] `airis gen --dry-run` shows `.airis/workspace-compose.yaml`
- [ ] `airis gen` writes to `.airis/workspace-compose.yaml`, skips `compose.yaml`
- [ ] `compose.yaml` at project root is not modified by `airis gen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)