### PR TITLE
chore: notify airis-mcp-gateway on release to auto-bump AIRIS_VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,8 +403,10 @@ jobs:
 
   # === MANUAL CUSTOMIZATION ===
   # Notify airis-mcp-gateway to bump AIRIS_VERSION after a successful release.
-  # Requires AIRIS_DISPATCH_TOKEN org-level secret: fine-grained PAT with
-  # `contents: write` on agiletec-inc/airis-mcp-gateway.
+  # Uses the agiletec-inc-homebrew-publisher GitHub App (already org-wide) to
+  # generate a short-lived token — no PAT or extra secret needed.
+  # One-time setup: add airis-mcp-gateway to the App's repository access list
+  # in GitHub App settings.
   notify-gateway:
     needs:
       - plan
@@ -412,10 +414,18 @@ jobs:
       - announce
     if: ${{ always() && needs.host.result == 'success' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
     runs-on: "ubuntu-22.04"
-    env:
-      GH_TOKEN: ${{ secrets.AIRIS_DISPATCH_TOKEN }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY }}
+          owner: agiletec-inc
+          repositories: airis-mcp-gateway
       - name: Dispatch AIRIS_VERSION bump to airis-mcp-gateway
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION=$(echo '${{ needs.plan.outputs.val }}' | jq -r '.releases[0].app_version')
           gh api repos/agiletec-inc/airis-mcp-gateway/dispatches \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,3 +400,25 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
+  # === MANUAL CUSTOMIZATION ===
+  # Notify airis-mcp-gateway to bump AIRIS_VERSION after a successful release.
+  # Requires AIRIS_DISPATCH_TOKEN org-level secret: fine-grained PAT with
+  # `contents: write` on agiletec-inc/airis-mcp-gateway.
+  notify-gateway:
+    needs:
+      - plan
+      - host
+      - announce
+    if: ${{ always() && needs.host.result == 'success' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.AIRIS_DISPATCH_TOKEN }}
+    steps:
+      - name: Dispatch AIRIS_VERSION bump to airis-mcp-gateway
+        run: |
+          VERSION=$(echo '${{ needs.plan.outputs.val }}' | jq -r '.releases[0].app_version')
+          gh api repos/agiletec-inc/airis-mcp-gateway/dispatches \
+            --method POST \
+            --field event_type=airis-workspace-released \
+            --field "client_payload[version]=$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,35 +400,3 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-
-  # === MANUAL CUSTOMIZATION ===
-  # Notify airis-mcp-gateway to bump AIRIS_VERSION after a successful release.
-  # Uses the agiletec-inc-homebrew-publisher GitHub App (already org-wide) to
-  # generate a short-lived token — no PAT or extra secret needed.
-  # One-time setup: add airis-mcp-gateway to the App's repository access list
-  # in GitHub App settings.
-  notify-gateway:
-    needs:
-      - plan
-      - host
-      - announce
-    if: ${{ always() && needs.host.result == 'success' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
-    runs-on: "ubuntu-22.04"
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.HOMEBREW_TAP_PUBLISHER_CLIENT_ID }}
-          private-key: ${{ secrets.HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY }}
-          owner: agiletec-inc
-          repositories: airis-mcp-gateway
-      - name: Dispatch AIRIS_VERSION bump to airis-mcp-gateway
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION=$(echo '${{ needs.plan.outputs.val }}' | jq -r '.releases[0].app_version')
-          gh api repos/agiletec-inc/airis-mcp-gateway/dispatches \
-            --method POST \
-            --field event_type=airis-workspace-released \
-            --field "client_payload[version]=$VERSION"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.17.11"
+version = "3.17.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.17.10"
+version = "3.17.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.17.9"
+version = "3.17.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.17.9"
+version = "3.17.10"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.17.11"
+version = "3.17.12"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.17.10"
+version = "3.17.11"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"


### PR DESCRIPTION
## Summary
- `release.yml` に `notify-gateway` ジョブを追加
- 非プレリリースの成功後、`airis-workspace-released` イベントを airis-mcp-gateway に dispatch
- gateway 側の `bump-airis-version.yml` が受け取り、Dockerfile の `AIRIS_VERSION` を自動更新 → PR → auto-merge → Docker イメージ再ビルド

## 必要なセットアップ（1回だけ）
org-level secret `AIRIS_DISPATCH_TOKEN` を追加する必要あり:
- Fine-grained PAT with `contents: write` on `agiletec-inc/airis-mcp-gateway`
- Settings → Secrets → Actions → Organization secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)