### PR TITLE
feat: compose gen root merge, MCP full coverage, guards non-interactive fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.0"
+version = "3.19.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.0"
+version = "3.19.1"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/guards/scripts.rs
+++ b/src/commands/guards/scripts.rs
@@ -95,6 +95,12 @@ fi
 if find_airis_context >/dev/null; then
     # We are in an airis docker-first project. Route to Docker via airis exec.
     if command -v airis &>/dev/null; then
+        # Non-interactive (no TTY on stdout): disable auto-up so that background
+        # scripts such as statusline commands and hooks don't trigger a full
+        # Docker stack launch when the container happens to be stopped.
+        if [[ ! -t 1 ]]; then
+            export AIRIS_NO_AUTO_UP=1
+        fi
         exec airis exec {cmd} "$@"
     else
         echo "❌ AIRIS: Context detected but 'airis' command not found." >&2


### PR DESCRIPTION
## Summary

- `airis gen` の出力先を `.airis/workspace-compose.yaml` → プロジェクトルート `compose.yaml` に変更。`x-airis-managed: true` マーカーによるマージ戦略でユーザー定義サービスを保護
- MCP ツールをワークスペース管理の11ツールから開発ライフサイクル全体の28ツールに拡張
- TTYなし環境（statusline・hooks）でのガードシム実行時に `AIRIS_NO_AUTO_UP=1` をセットし、コンテナ停止中の意図しない `airis up` を抑制

## Commits

- `feat(gen)`: write compose.yaml at project root with merge semantics
- `feat(mcp)`: expand MCP tools to cover full development lifecycle
- `docs`: update agile-deploy refs to agile-server in IDEAL_STATE
- `fix(guards)`: suppress auto-up in non-interactive contexts

Supersedes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)