### PR TITLE
policy(guards): discourage global shims, recommend project-local only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.1"
+version = "3.19.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.1"
+version = "3.19.2"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,9 +24,10 @@ QUICK REFERENCE:
   airis doctor              Diagnose and fix workspace issues
 
 SMART SHIMS:
-  Run `airis guards install --global` to enable transparent redirection for
-  pnpm, npm, uv, python, and more. When a compose.yml is detected, these
-  commands automatically execute inside Docker.
+  Run `airis guards install` inside a project to enable transparent redirection
+  for pnpm, npm, uv, python, and more. Commands are automatically routed to
+  Docker when a compose.yml is detected. Global shims (~/.airis/bin) are
+  intentionally not recommended — use project-local guards instead.
 
 CONVENTIONS:
   airis automatically discovers projects in apps/* and libs/*. Use manifest.toml


### PR DESCRIPTION
## Summary

- グローバルシム（`--global`）はデイリーコマンド（pnpm, python 等）をシステム全体でインターセプトするため、airis プロジェクト外や Docker 停止中に意図せずブロックされる UX 問題がある
- 方針変更: `airis guards install` はプロジェクトローカルのみ推奨。`--global` は明示的に望む場合のみ使用可
- CLI のクイックリファレンスとヘルプテキストを更新

## Changes

- `src/cli.rs`: SMART SHIMS セクションをプロジェクトローカル推奨に書き換え

🤖 Generated with [Claude Code](https://claude.com/claude-code)