### PR TITLE
fix(guards): single-quote command name in generated guard scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.4"
+version = "3.19.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.4"
+version = "3.19.5"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/guards/scripts.rs
+++ b/src/commands/guards/scripts.rs
@@ -79,7 +79,7 @@ find_airis_context() {{
     return 1
 }}
 
-REAL_CMD=$(find_real_cmd {cmd})
+REAL_CMD=$(find_real_cmd '{cmd}')
 
 # 0. Explicit bypass: AIRIS_BYPASS=1 or `airis host <cmd>`
 if [[ "${{AIRIS_BYPASS:-}}" == "1" ]]; then
@@ -101,7 +101,7 @@ if find_airis_context >/dev/null; then
         if [[ ! -t 1 ]]; then
             export AIRIS_NO_AUTO_UP=1
         fi
-        exec airis exec {cmd} "$@"
+        exec airis exec '{cmd}' "$@"
     else
         echo "❌ AIRIS: Context detected but 'airis' command not found." >&2
         echo "   Cannot route to Docker. Host execution is blocked for hygiene." >&2

--- a/src/commands/guards/tests.rs
+++ b/src/commands/guards/tests.rs
@@ -56,12 +56,32 @@ fn installed_shim_invokes_airis_exec_with_cmd_only() {
 
     let content = fs::read_to_string(dir.path().join("pnpm")).unwrap();
     assert!(
-        content.contains("exec airis exec pnpm \"$@\""),
+        content.contains("exec airis exec 'pnpm' \"$@\""),
         "shim must hand off to `airis exec <cmd>` for auto-routing. Got:\n{content}"
     );
     assert!(
         !content.contains("exec airis exec workspace"),
         "Phase 0 workaround must be gone now that auto-routing exists. Got:\n{content}"
+    );
+}
+
+#[test]
+fn generated_script_single_quotes_command_name() {
+    // Defense-in-depth (issue #247): the command name must be single-quoted at
+    // every interpolation point so a future unvalidated command name cannot
+    // break out of its shell token. `validate_guard_cmd` already restricts the
+    // charset, but the template must not rely on that alone.
+    let dir = tempfile::tempdir().unwrap();
+    install_global_guard(dir.path(), "pnpm", GuardLevel::Enforce).unwrap();
+
+    let content = fs::read_to_string(dir.path().join("pnpm")).unwrap();
+    assert!(
+        content.contains("REAL_CMD=$(find_real_cmd 'pnpm')"),
+        "command name passed to find_real_cmd must be single-quoted. Got:\n{content}"
+    );
+    assert!(
+        content.contains("exec airis exec 'pnpm' \"$@\""),
+        "command name passed to `airis exec` must be single-quoted. Got:\n{content}"
     );
 }
 


### PR DESCRIPTION
## 概要

Issue #247 の修正。ガードスクリプトテンプレートで `{cmd}` がクォートなしで2箇所に埋め込まれていた問題を、シングルクォートで囲む防御的設計に変更。

## 問題

`src/commands/guards/scripts.rs` のスクリプトテンプレートで:

```bash
REAL_CMD=$(find_real_cmd {cmd})    # クォートなし
exec airis exec {cmd} "$@"         # クォートなし
```

`validate_guard_cmd()` の文字制限（`[a-zA-Z0-9._+-]`）で直接悪用は困難だが、将来コマンドが追加される際の検証漏れリスクがある。

## 修正

両方の埋め込み箇所をシングルクォートで囲んだ:

```bash
REAL_CMD=$(find_real_cmd '{cmd}')
exec airis exec '{cmd}' "$@"
```

文字制限がシングルクォート自体を禁止しているため、クォートからの脱出は不可能。

## テスト

- 再現テスト `generated_script_single_quotes_command_name` を追加（修正前は失敗、修正後はパス）
- 既存の end-to-end shim テスト `shim_routes_to_airis_exec_inside_workspace` で bash がクォート付きトークンを正しく解決することを確認
- `cargo fmt --check` / `cargo clippy -- -D warnings` / 全テスト（lib + integration）パス

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)