### PR TITLE
fix(host): make `airis host` compile on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.5"
+version = "3.19.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.5"
+version = "3.19.6"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -1,6 +1,5 @@
 use anyhow::{Result, bail};
 use std::env;
-use std::os::unix::process::CommandExt;
 use std::process::Command;
 
 /// Run a host command bypassing airis guards (`AIRIS_BYPASS=1`).
@@ -9,13 +8,13 @@ pub fn run(cmd: &[String]) -> Result<()> {
         .split_first()
         .expect("cmd is non-empty (enforced by clap)");
 
-    // Find the real binary, excluding ~/.airis/bin so we don't re-enter the guard.
-    let real_path = env::var("PATH")
-        .unwrap_or_default()
-        .split(':')
-        .filter(|p| !p.contains(".airis/bin"))
+    // Find the real binary, excluding ~/.airis/bin so we don't re-enter the
+    // guard. `split_paths` applies the platform-correct PATH separator.
+    let path_var = env::var_os("PATH").unwrap_or_default();
+    let real_path = env::split_paths(&path_var)
+        .filter(|p| !p.to_string_lossy().contains(".airis/bin"))
         .find_map(|p| {
-            let candidate = std::path::Path::new(p).join(name);
+            let candidate = p.join(name);
             candidate.is_file().then_some(candidate)
         });
 
@@ -23,10 +22,25 @@ pub fn run(cmd: &[String]) -> Result<()> {
         bail!("'{}' not found on host PATH (excluding ~/.airis/bin)", name);
     };
 
-    let err = Command::new(&binary)
-        .args(args)
-        .env("AIRIS_BYPASS", "1")
-        .exec();
+    let mut command = Command::new(&binary);
+    command.args(args).env("AIRIS_BYPASS", "1");
 
-    bail!("failed to exec {}: {}", binary.display(), err);
+    // On Unix, replace the current process via exec(2) so signals and the exit
+    // code pass through transparently. Windows has no exec(2): spawn the child,
+    // wait for it, and propagate its exit code instead.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = command.exec();
+        bail!("failed to exec {}: {}", binary.display(), err);
+    }
+
+    #[cfg(not(unix))]
+    {
+        use anyhow::Context;
+        let status = command
+            .status()
+            .with_context(|| format!("failed to run {}", binary.display()))?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
 }


### PR DESCRIPTION
## 概要

v3.19.5 のリリースで cargo-dist の Windows ビルド（`x86_64-pc-windows-msvc`）がコンパイルエラーになり、GitHub Release / Homebrew tap の生成が skip された問題を修正。

## 原因

`src/commands/host.rs` が Unix 専用 API を `#[cfg]` ガードなしで使用していた:

```rust
use std::os::unix::process::CommandExt;  // Windows に存在しない
...
.exec();                                  // Unix 専用メソッド
```

→ `error[E0433]: cannot find 'unix' in 'os'` / `error[E0599]: no method named 'exec'`

前回リリース v3.6.7 以降に混入した既存の cross-platform バグ（#247 のセキュリティ修正とは無関係）。crates.io publish はネイティブビルド前のため成功していた。

## 修正

- `exec(2)` によるプロセス置換を `#[cfg(unix)]` でガード
- `#[cfg(not(unix))]` パスを追加 — Windows には `exec(2)` がないため、子プロセスを spawn → wait → 終了コードを伝播
- ハードコードの `:` 区切り PATH 分割を `env::split_paths` に置換（プラットフォーム正準のセパレータを使用）

## 検証

- macOS（Unix）で `cargo fmt --check` / `cargo clippy -- -D warnings` / 全テスト（lib + integration）パス
- Windows コンパイルの最終確認は再タグ（v3.19.6）のリリースパイプライン（Windows runner）で行う。ローカルのクロスコンパイルは `ring` クレートの C 依存が Windows SDK ヘッダを要求するためブロックされる

## 補足

ci.yml は Windows ビルドを行っていないため、このバグはリリース時まで検出されなかった。再発防止に Windows 向け `cargo check` ジョブの追加を別途検討推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)