### PR TITLE
ci: add Windows compile check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,24 @@ jobs:
           fi
           echo "OK: under limit"
 
+  windows-check:
+    # Catches Windows-only compilation breakage (e.g. unguarded `std::os::unix`
+    # APIs) before it reaches the cargo-dist release pipeline. Runs natively on
+    # a Windows runner — free for public repos and avoids the Windows SDK
+    # headers that a Linux cross-compile of native deps (ring) would require.
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - name: Cargo check
+        run: cargo check --all-targets
+
   dependency-audit:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.6"
+version = "3.19.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.6"
+version = "3.19.7"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"


### PR DESCRIPTION
## 概要

CI に Windows ネイティブのコンパイルチェックジョブを追加。

## 背景

`src/commands/host.rs` の Windows 非対応コード（`#[cfg]` ガードなしの `std::os::unix` API）が、cargo-dist のリリースパイプラインで失敗するまで検出されなかった。原因は **CI が Linux でしかビルドしていなかった**こと。

## 変更

`ci.yml` に `windows-check` ジョブを追加:
- `windows-latest` ランナーでネイティブに `cargo check --all-targets`
- public リポなので Windows ランナーは無料
- ネイティブ実行により、Linux からのクロスコンパイルで native 依存（`ring`）が要求する Windows SDK ヘッダ問題を回避

これにより host.rs のような Windows 限定の破壊がリリース前に PR で検出される。

## 検証

この PR 自体で `windows-check` ジョブが実行され、現在の main が Windows で通ることを確認できる。

## 補足

`windows-check` を必須チェックにする場合は、リポジトリの branch protection に別途追加が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)