### PR TITLE
fix(mcp): validate manifest before writing in manifest_apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.7"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.7"
+version = "3.20.0"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -631,12 +631,27 @@ fn handle_manifest_apply(arguments: &Value) -> Result<Value> {
         .context("Missing manifest content")?;
     let run_gen = arguments["run_gen"].as_bool().unwrap_or(true);
 
-    // 1. Write to disk
+    // 1. Parse + validate before touching disk so an invalid manifest can
+    //    never corrupt the workspace. `Manifest::parse` performs both TOML
+    //    parsing and consistency validation.
+    if let Err(e) = Manifest::parse(content) {
+        return Ok(json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": format!("Invalid manifest, manifest.toml not modified:\n{:#}", e)
+                }
+            ],
+            "isError": true
+        }));
+    }
+
+    // 2. Write to disk
     std::fs::write("manifest.toml", content)?;
 
     let mut response_text = "Manifest written to manifest.toml.".to_string();
 
-    // 2. Optionally run gen
+    // 3. Optionally run gen
     if run_gen {
         // Load the manifest we just wrote to ensure we're using the latest
         let _manifest = Manifest::load(Path::new("manifest.toml"))?;
@@ -1031,5 +1046,38 @@ mod tests {
         // advertised list, so reads should be refused.
         let err = handle_resources_read("file:///Cargo.lock").unwrap_err();
         assert!(err.to_string().contains("not advertised"));
+    }
+
+    #[test]
+    fn handle_manifest_apply_rejects_invalid_toml() {
+        // Syntactically broken TOML must be refused with an error response
+        // before any disk write. `run_gen` is off so the handler never reaches
+        // the write/gen path and never shells out to `airis gen`.
+        let args = json!({ "manifest": "this = = not valid toml", "run_gen": false });
+        let result = handle_manifest_apply(&args).unwrap();
+
+        assert_eq!(result["isError"], json!(true));
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("not modified")
+        );
+    }
+
+    #[test]
+    fn handle_manifest_apply_rejects_manifest_failing_validation() {
+        // An empty document is valid TOML but fails consistency validation
+        // (project.id is required). It must still be rejected before writing.
+        let args = json!({ "manifest": "", "run_gen": false });
+        let result = handle_manifest_apply(&args).unwrap();
+
+        assert_eq!(result["isError"], json!(true));
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("not modified")
+        );
     }
 }


### PR DESCRIPTION
## 問題 (#248)

`handle_manifest_apply()` は MCP クライアントから受け取った内容を検証せず `manifest.toml` へ直接書き込んでいた。無効な TOML や不整合なマニフェストが書き込まれるとワークスペースが壊れる。`manifest_validate` ツールは別途あるが advisory で強制されていなかった。

## 修正

- 書き込み前に `Manifest::parse()` を通す。`Manifest::parse()` は TOML パースと整合性バリデーション (`validate()`) の両方を実行する (`src/manifest/mod.rs:58-79`)
- 失敗時は `isError: true` の MCP レスポンスを返し、`manifest.toml` は一切変更しない
- issue 提案の `parse()` → `validate()` 2段構成は、`parse()` が内部で既に `validate()` を呼ぶため validation エラーが「Parsing failed」分岐に入る死んだコードになる。単一エラーパスに統一した

## テスト

- 再現テスト2件を追加 (不正 TOML / バリデーション失敗 = 空ドキュメントで `project.id` 欠落)
- `cargo test` 全 366 (lib) + 20 (cli_test) パス、`cargo fmt --check` / `cargo clippy -- -D warnings` パス

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)