### PR TITLE
feat(claude): terminal tab-title status indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `workspace_doctor`, `workspace_verify`, `workspace_status` (in addition to the
   existing `workspace_init`, `workspace_cleanup`, `workspace_discover`,
   `manifest_validate`, `manifest_apply`, `migration_execute`).
+- **Terminal tab-title status indicator.** `airis claude setup` now injects
+  Claude Code hooks that set the terminal tab title to `<emoji> <repo>`,
+  reflecting the agent's state: running (🏃), waiting for user input (✋), or
+  idle (no emoji). Emojis are configurable in `~/.airis/global-config.toml`
+  under `[claude.terminal_title]` (`enabled` / `running` / `waiting` / `idle`)
+  and read at hook time, so changes apply without re-running setup. Hooks call
+  the hidden `airis claude tab-title <state>` handler. `airis claude uninstall`
+  removes the hooks; legacy hand-written `warp-tab-title.sh` hooks are migrated
+  away automatically.
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.7"
+version = "3.19.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.7"
+version = "3.19.8"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -498,6 +498,35 @@ pub enum ClaudeCommands {
     Setup,
     Status,
     Uninstall,
+    /// Hook handler: emit a terminal-title escape sequence (invoked by Claude Code hooks)
+    #[command(hide = true)]
+    TabTitle {
+        /// Agent state to reflect in the tab title
+        #[arg(value_enum)]
+        state: TabTitleState,
+    },
+}
+
+/// Agent state for the terminal tab-title indicator
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum TabTitleState {
+    /// Idle — session start or turn complete (no emoji)
+    Idle,
+    /// Running — agent is working
+    Running,
+    /// Waiting — waiting for user input (questions, approvals)
+    Waiting,
+}
+
+impl TabTitleState {
+    /// Lowercase identifier used in hook command strings.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TabTitleState::Idle => "idle",
+            TabTitleState::Running => "running",
+            TabTitleState::Waiting => "waiting",
+        }
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/commands/claude_setup/mod.rs
+++ b/src/commands/claude_setup/mod.rs
@@ -1,4 +1,6 @@
 pub mod dir_sync;
+pub mod settings_hooks;
+pub mod tab_title;
 pub mod templates;
 
 #[cfg(test)]
@@ -11,7 +13,17 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use serde_json::Value;
 
-use crate::manifest::GlobalConfig;
+use crate::manifest::{GlobalConfig, TerminalTitleSection};
+
+/// Resolve the absolute path of the running `airis` binary, for embedding in
+/// hook commands. Falls back to the bare name (relies on `$PATH`) if the path
+/// cannot be determined.
+fn airis_bin_path() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(str::to_string))
+        .unwrap_or_else(|| "airis".to_string())
+}
 
 /// Plugin ID in installed_plugins.json
 const AIRIS_PLUGIN_ID: &str = "airis-mcp-gateway@airis-mcp-gateway";
@@ -228,6 +240,32 @@ pub fn setup_global() -> Result<()> {
         println!();
     }
 
+    // 6. Inject terminal tab-title hooks into settings.json
+    let terminal_title = &global_config.claude.terminal_title;
+    let airis_bin = airis_bin_path();
+    let hook_result = settings_hooks::apply(&home, &airis_bin, terminal_title)?;
+    if hook_result.migrated_legacy {
+        println!("  {} Migrated legacy warp-tab-title.sh hooks", "✓".green());
+        println!(
+            "     {} {} is no longer referenced — delete it if unused",
+            "ℹ".dimmed(),
+            "~/.claude/hooks/warp-tab-title.sh".dimmed()
+        );
+    }
+    if hook_result.injected > 0 {
+        println!(
+            "  {} Terminal tab-title hooks installed ({} events)",
+            "✓".green(),
+            hook_result.injected
+        );
+    } else if !terminal_title.enabled {
+        println!(
+            "  {} Terminal tab-title disabled ([claude.terminal_title] enabled = false)",
+            "–".dimmed()
+        );
+    }
+    println!();
+
     println!("{}", "✅ Global configuration synced".green());
 
     Ok(())
@@ -287,6 +325,32 @@ pub fn status() -> Result<()> {
                 all_synced = false;
             }
         }
+    }
+
+    // Terminal tab-title hooks
+    println!();
+    println!("  Terminal title:");
+    let terminal_title = &global_config.claude.terminal_title;
+    let managed_hooks = settings_hooks::count_managed_entries(&home);
+    if terminal_title.enabled {
+        let idle_label = if terminal_title.idle.is_empty() {
+            "—".to_string()
+        } else {
+            terminal_title.idle.clone()
+        };
+        print_status(
+            &format!(
+                "  enabled (running {} / waiting {} / idle {})",
+                terminal_title.running, terminal_title.waiting, idle_label
+            ),
+            managed_hooks > 0,
+        );
+        if managed_hooks == 0 {
+            println!("    (run `airis claude setup` to install hooks)");
+            all_synced = false;
+        }
+    } else {
+        println!("    {} disabled in [claude.terminal_title]", "–".dimmed());
     }
 
     // Legacy check
@@ -352,7 +416,16 @@ pub fn uninstall() -> Result<()> {
         fs::remove_file(&reg_path)?;
     }
 
-    // 3. Clean legacy hooks
+    // 3. Remove terminal tab-title hooks from settings.json
+    let disabled = TerminalTitleSection {
+        enabled: false,
+        ..TerminalTitleSection::default()
+    };
+    let airis_bin = airis_bin_path();
+    settings_hooks::apply(&home, &airis_bin, &disabled)?;
+    println!("   {} Removed terminal tab-title hooks", "✓".green());
+
+    // 4. Clean legacy hooks
     clean_legacy_hooks(&home)?;
 
     println!();

--- a/src/commands/claude_setup/settings_hooks.rs
+++ b/src/commands/claude_setup/settings_hooks.rs
@@ -1,0 +1,190 @@
+// settings.json hook injection for the terminal tab-title feature.
+//
+// `airis claude setup` injects (and `airis claude uninstall` removes) hook
+// entries that call `airis claude tab-title <state>`. The injection is
+// idempotent: every run first strips all airis-managed tab-title entries
+// (identified by a marker substring in the hook command), then re-adds the
+// current set. Entries that don't carry the marker — including the user's own
+// hooks and the `type:"agent"` airis-verify Stop hook — are never touched.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde_json::{Value, json};
+
+use crate::manifest::TerminalTitleSection;
+
+/// Marker substring identifying an airis-managed tab-title hook command.
+const MARKER: &str = "claude tab-title";
+/// Marker for the legacy hand-written shell-script hook (migrated away).
+const LEGACY_SCRIPT_MARKER: &str = "warp-tab-title.sh";
+
+/// Hook events and the agent state each one reports.
+/// `matcher` follows Claude Code's hook schema (regex for tool events).
+const HOOK_EVENTS: &[(&str, &str, &str)] = &[
+    ("SessionStart", "", "idle"),
+    ("UserPromptSubmit", "", "running"),
+    ("PostToolUse", "", "running"),
+    ("PreToolUse", "AskUserQuestion|ExitPlanMode", "waiting"),
+    ("Notification", "", "waiting"),
+    ("Stop", "", "idle"),
+];
+
+/// Outcome of an `apply` call.
+pub struct HookSyncResult {
+    /// Number of tab-title hook entries injected (0 when disabled).
+    pub injected: usize,
+    /// True when legacy `warp-tab-title.sh` entries were migrated away.
+    pub migrated_legacy: bool,
+}
+
+/// Inject or remove airis-managed tab-title hook entries in settings.json.
+///
+/// When `cfg.enabled` is false, entries are only removed.
+pub fn apply(
+    claude_home: &Path,
+    airis_bin: &str,
+    cfg: &TerminalTitleSection,
+) -> Result<HookSyncResult> {
+    let settings_path = claude_home.join("settings.json");
+
+    let mut settings: Value = if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)
+            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+        match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "   {} {} is not valid JSON ({}); skipping tab-title hooks",
+                    "⚠".yellow(),
+                    settings_path.display(),
+                    e
+                );
+                return Ok(HookSyncResult {
+                    injected: 0,
+                    migrated_legacy: false,
+                });
+            }
+        }
+    } else {
+        json!({})
+    };
+
+    let result = mutate(&mut settings, airis_bin, cfg.enabled);
+
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let mut content = serde_json::to_string_pretty(&settings)?;
+    content.push('\n');
+    fs::write(&settings_path, content)
+        .with_context(|| format!("Failed to write {}", settings_path.display()))?;
+
+    Ok(result)
+}
+
+/// Pure settings.json mutation: strip managed entries, optionally re-add.
+/// Separated from I/O so it can be unit-tested directly.
+pub fn mutate(settings: &mut Value, airis_bin: &str, enabled: bool) -> HookSyncResult {
+    // Defensive: settings.json is always a JSON object in practice, but never
+    // panic on a malformed top-level value.
+    if !settings.is_object() {
+        *settings = json!({});
+    }
+    if !settings.get("hooks").map(Value::is_object).unwrap_or(false) {
+        settings["hooks"] = json!({});
+    }
+
+    let mut migrated_legacy = false;
+
+    // Phase 1: strip all existing tab-title / legacy entries from every event.
+    if let Some(hooks) = settings["hooks"].as_object_mut() {
+        for entries in hooks.values_mut() {
+            if let Some(arr) = entries.as_array_mut() {
+                arr.retain(|entry| {
+                    let (is_managed, is_legacy) = classify_entry(entry);
+                    if is_legacy {
+                        migrated_legacy = true;
+                    }
+                    !is_managed
+                });
+            }
+        }
+    }
+
+    // Phase 2: re-add the current entry set (skipped when disabled).
+    let mut injected = 0;
+    if enabled {
+        let hooks = settings["hooks"].as_object_mut().expect("hooks is object");
+        for (event, matcher, state) in HOOK_EVENTS {
+            // Quote the binary path so an install path with spaces still works.
+            let command = format!("\"{}\" claude tab-title {}", airis_bin, state);
+            let entry = json!({
+                "matcher": matcher,
+                "hooks": [{ "type": "command", "command": command }],
+            });
+            hooks
+                .entry((*event).to_string())
+                .or_insert_with(|| json!([]))
+                .as_array_mut()
+                .expect("event value is array")
+                .push(entry);
+            injected += 1;
+        }
+    }
+
+    HookSyncResult {
+        injected,
+        migrated_legacy,
+    }
+}
+
+/// Classify a hook entry. Returns `(is_managed, is_legacy)`:
+/// - `is_managed`: an airis tab-title entry (current or legacy) — remove it
+///   before re-adding.
+/// - `is_legacy`: references the old `warp-tab-title.sh` script.
+///
+/// Entries without a `hooks[].command` string — e.g. `type:"agent"` hooks —
+/// never match, so user hooks and the airis-verify Stop hook are preserved.
+fn classify_entry(entry: &Value) -> (bool, bool) {
+    let Some(hooks) = entry.get("hooks").and_then(|h| h.as_array()) else {
+        return (false, false);
+    };
+    let mut managed = false;
+    let mut legacy = false;
+    for hook in hooks {
+        if let Some(cmd) = hook.get("command").and_then(|c| c.as_str()) {
+            if cmd.contains(LEGACY_SCRIPT_MARKER) {
+                managed = true;
+                legacy = true;
+            } else if cmd.contains(MARKER) {
+                managed = true;
+            }
+        }
+    }
+    (managed, legacy)
+}
+
+/// Count airis-managed tab-title hook entries currently in settings.json.
+/// Used by `status()`.
+pub fn count_managed_entries(claude_home: &Path) -> usize {
+    let settings_path = claude_home.join("settings.json");
+    let Ok(content) = fs::read_to_string(&settings_path) else {
+        return 0;
+    };
+    let Ok(settings) = serde_json::from_str::<Value>(&content) else {
+        return 0;
+    };
+    let Some(hooks) = settings.get("hooks").and_then(|h| h.as_object()) else {
+        return 0;
+    };
+    hooks
+        .values()
+        .filter_map(|entries| entries.as_array())
+        .flatten()
+        .filter(|entry| classify_entry(entry).0)
+        .count()
+}

--- a/src/commands/claude_setup/tab_title.rs
+++ b/src/commands/claude_setup/tab_title.rs
@@ -1,0 +1,95 @@
+// Terminal tab-title hook handler.
+//
+// Claude Code hooks run WITHOUT a controlling terminal, so a hook cannot write
+// an OSC escape sequence directly. Claude Code provides the `terminalSequence`
+// hook-output field: the hook prints JSON on stdout and Claude Code emits the
+// (allowlisted) OSC sequence on the hook's behalf. Allowed OSC codes: 0, 1, 2,
+// 9, 99, 777, BEL.
+//
+// This handler is invoked as `airis claude tab-title <state>` from hook entries
+// that `airis claude setup` injects into ~/.claude/settings.json.
+
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::Result;
+use serde_json::{Value, json};
+
+use crate::cli::TabTitleState;
+use crate::manifest::GlobalConfig;
+
+/// Emit a terminal-title escape sequence for the given agent state.
+pub fn emit(state: TabTitleState) -> Result<()> {
+    let config = GlobalConfig::load()?;
+    let cfg = &config.claude.terminal_title;
+
+    // Feature disabled: emit nothing so the hook is a harmless no-op.
+    if !cfg.enabled {
+        return Ok(());
+    }
+
+    let emoji = match state {
+        TabTitleState::Idle => &cfg.idle,
+        TabTitleState::Running => &cfg.running,
+        TabTitleState::Waiting => &cfg.waiting,
+    };
+
+    let title = build_title(emoji, &repo_name());
+
+    // OSC 0 = set icon name + window/tab title (BEL-terminated).
+    let osc = format!("\u{1b}]0;{}\u{7}", title);
+    println!("{}", json!({ "terminalSequence": osc }));
+    Ok(())
+}
+
+/// Build the tab title string: `<emoji> <repo>`, or just `<repo>` when the
+/// emoji is empty (the idle state defaults to no emoji).
+fn build_title(emoji: &str, repo: &str) -> String {
+    if emoji.is_empty() {
+        repo.to_string()
+    } else {
+        format!("{} {}", emoji, repo)
+    }
+}
+
+/// Resolve the repo name from the hook payload's `cwd` (stdin JSON),
+/// falling back to `$PWD`, then a generic label.
+fn repo_name() -> String {
+    let cwd = read_cwd_from_stdin()
+        .or_else(|| std::env::var("PWD").ok())
+        .unwrap_or_default();
+
+    Path::new(&cwd)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "claude".to_string())
+}
+
+/// Read the hook JSON payload from stdin and extract a non-empty `.cwd`.
+fn read_cwd_from_stdin() -> Option<String> {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).ok()?;
+    let value: Value = serde_json::from_str(&input).ok()?;
+    value
+        .get("cwd")
+        .and_then(|c| c.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_title;
+
+    #[test]
+    fn title_with_emoji() {
+        assert_eq!(build_title("🏃", "agiletec-inc"), "🏃 agiletec-inc");
+        assert_eq!(build_title("✋", "airis-workspace"), "✋ airis-workspace");
+    }
+
+    #[test]
+    fn title_without_emoji_is_repo_only() {
+        assert_eq!(build_title("", "agiletec-inc"), "agiletec-inc");
+    }
+}

--- a/src/commands/claude_setup/tests.rs
+++ b/src/commands/claude_setup/tests.rs
@@ -416,6 +416,156 @@ fn test_no_infra_constants_in_templates() {
     );
 }
 
+// ── Terminal tab-title hook tests ───────────────────────────────────
+
+use super::settings_hooks::{apply, count_managed_entries, mutate};
+use crate::manifest::TerminalTitleSection;
+
+fn total_hook_entries(settings: &serde_json::Value) -> usize {
+    settings["hooks"]
+        .as_object()
+        .unwrap()
+        .values()
+        .map(|a| a.as_array().unwrap().len())
+        .sum()
+}
+
+#[test]
+fn test_tab_title_mutate_injects_six_events() {
+    let mut settings = json!({});
+    let result = mutate(&mut settings, "/usr/local/bin/airis", true);
+    assert_eq!(result.injected, 6);
+    let hooks = settings["hooks"].as_object().unwrap();
+    for event in [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PostToolUse",
+        "PreToolUse",
+        "Notification",
+        "Stop",
+    ] {
+        assert_eq!(hooks[event].as_array().unwrap().len(), 1, "{event}");
+    }
+}
+
+#[test]
+fn test_tab_title_mutate_is_idempotent() {
+    let mut settings = json!({});
+    mutate(&mut settings, "/bin/airis", true);
+    mutate(&mut settings, "/bin/airis", true);
+    assert_eq!(
+        total_hook_entries(&settings),
+        6,
+        "re-apply must not duplicate entries"
+    );
+}
+
+#[test]
+fn test_tab_title_mutate_disabled_removes_all() {
+    let mut settings = json!({});
+    mutate(&mut settings, "/bin/airis", true);
+    let result = mutate(&mut settings, "/bin/airis", false);
+    assert_eq!(result.injected, 0);
+    assert_eq!(total_hook_entries(&settings), 0);
+}
+
+#[test]
+fn test_tab_title_preserves_agent_stop_hook() {
+    // The airis-verify Stop hook is type:"agent" with no `command` field —
+    // it must survive both injection and removal.
+    let mut settings = json!({
+        "hooks": {
+            "Stop": [
+                {
+                    "matcher": "",
+                    "hooks": [{ "type": "agent", "prompt": "run airis verify", "timeout": 300 }]
+                }
+            ]
+        }
+    });
+    mutate(&mut settings, "/bin/airis", true);
+    let stop = settings["hooks"]["Stop"].as_array().unwrap();
+    assert_eq!(stop.len(), 2, "agent hook + injected tab-title hook");
+    assert!(stop.iter().any(|e| e["hooks"][0]["type"] == "agent"));
+
+    mutate(&mut settings, "/bin/airis", false);
+    let stop = settings["hooks"]["Stop"].as_array().unwrap();
+    assert_eq!(stop.len(), 1, "only the agent hook remains");
+    assert_eq!(stop[0]["hooks"][0]["type"], "agent");
+}
+
+#[test]
+fn test_tab_title_migrates_legacy_script_hooks() {
+    let mut settings = json!({
+        "hooks": {
+            "Stop": [
+                {
+                    "matcher": "",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "sh \"$HOME/.claude/hooks/warp-tab-title.sh\" idle"
+                    }]
+                }
+            ]
+        }
+    });
+    let result = mutate(&mut settings, "/bin/airis", true);
+    assert!(result.migrated_legacy);
+    let stop = settings["hooks"]["Stop"].as_array().unwrap();
+    assert_eq!(stop.len(), 1, "legacy entry replaced by managed one");
+    let cmd = stop[0]["hooks"][0]["command"].as_str().unwrap();
+    assert!(cmd.contains("claude tab-title idle"));
+    assert!(!cmd.contains("warp-tab-title.sh"));
+}
+
+#[test]
+fn test_tab_title_preserves_unrelated_user_hooks() {
+    let mut settings = json!({
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{ "type": "command", "command": "my-custom-hook.sh" }]
+                }
+            ]
+        }
+    });
+    mutate(&mut settings, "/bin/airis", true);
+    let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
+    assert_eq!(pre.len(), 2, "user hook + injected waiting hook");
+    assert!(pre.iter().any(|e| e["hooks"][0]["command"] == "my-custom-hook.sh"));
+
+    mutate(&mut settings, "/bin/airis", false);
+    let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
+    assert_eq!(pre.len(), 1);
+    assert_eq!(pre[0]["hooks"][0]["command"], "my-custom-hook.sh");
+}
+
+#[test]
+fn test_tab_title_apply_writes_file_and_counts() {
+    let claude = tempfile::tempdir().unwrap();
+    let result = apply(claude.path(), "/bin/airis", &TerminalTitleSection::default()).unwrap();
+    assert_eq!(result.injected, 6);
+    assert!(claude.path().join("settings.json").exists());
+    assert_eq!(count_managed_entries(claude.path()), 6);
+
+    let disabled = TerminalTitleSection {
+        enabled: false,
+        ..TerminalTitleSection::default()
+    };
+    apply(claude.path(), "/bin/airis", &disabled).unwrap();
+    assert_eq!(count_managed_entries(claude.path()), 0);
+}
+
+#[test]
+fn test_tab_title_apply_handles_corrupt_settings() {
+    let claude = tempfile::tempdir().unwrap();
+    fs::write(claude.path().join("settings.json"), "{ not json").unwrap();
+    // Corrupt settings.json is skipped with a warning, never panics or errors.
+    let result = apply(claude.path(), "/bin/airis", &TerminalTitleSection::default()).unwrap();
+    assert_eq!(result.injected, 0);
+}
+
 #[test]
 fn test_registry_load_save_roundtrip() {
     let file = tempfile::NamedTempFile::new().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ fn dispatch(command: Commands) -> Result<()> {
             ClaudeCommands::Setup => commands::claude_setup::setup_global()?,
             ClaudeCommands::Status => commands::claude_setup::status()?,
             ClaudeCommands::Uninstall => commands::claude_setup::uninstall()?,
+            ClaudeCommands::TabTitle { state } => commands::claude_setup::tab_title::emit(state)?,
         },
         Commands::Guards { action } => match action {
             GuardsCommands::Install {

--- a/src/manifest/global_config.rs
+++ b/src/manifest/global_config.rs
@@ -101,18 +101,64 @@ impl GlobalGuardsSection {
 pub struct GlobalClaudeSection {
     #[serde(default = "default_claude_source")]
     pub source: String,
+    /// Terminal tab-title status indicator
+    #[serde(default)]
+    pub terminal_title: TerminalTitleSection,
 }
 
 impl Default for GlobalClaudeSection {
     fn default() -> Self {
         GlobalClaudeSection {
             source: default_claude_source(),
+            terminal_title: TerminalTitleSection::default(),
         }
     }
 }
 
 fn default_claude_source() -> String {
     "~/.airis/claude".to_string()
+}
+
+/// Terminal tab-title status indicator config.
+/// airis manages Claude Code hooks that set the terminal tab title to
+/// `<emoji> <repo>`, reflecting the agent's current state.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct TerminalTitleSection {
+    /// Whether airis manages terminal-title hooks in ~/.claude/settings.json
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Emoji shown while the agent is running
+    #[serde(default = "default_running_emoji")]
+    pub running: String,
+    /// Emoji shown while waiting for user input (questions, approvals)
+    #[serde(default = "default_waiting_emoji")]
+    pub waiting: String,
+    /// Emoji shown when idle (session start, turn complete). Empty = no emoji.
+    #[serde(default)]
+    pub idle: String,
+}
+
+impl Default for TerminalTitleSection {
+    fn default() -> Self {
+        TerminalTitleSection {
+            enabled: true,
+            running: default_running_emoji(),
+            waiting: default_waiting_emoji(),
+            idle: String::new(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_running_emoji() -> String {
+    "🏃".to_string()
+}
+
+fn default_waiting_emoji() -> String {
+    "✋".to_string()
 }
 
 /// Strategy for backing up files before modification


### PR DESCRIPTION
## 概要

Claude Code のターミナルタブタイトルにエージェントの状態を絵文字で表示する機能を `airis` に追加。`airis claude setup` が hook を注入し、タブタイトルを `<emoji> <repo>` に設定する。

| 状態 | イベント | デフォルト絵文字 |
|---|---|---|
| running | UserPromptSubmit / PostToolUse | 🏃 |
| waiting | PreToolUse(AskUserQuestion\|ExitPlanMode)/ Notification | ✋ |
| idle | SessionStart / Stop | なし |

## 変更点

- **`[claude.terminal_title]` 設定** を `global-config.toml` に追加（`enabled` / `running` / `waiting` / `idle`）。hook 実行時に読むため、絵文字変更は再 setup 不要。
- **隠しサブコマンド `airis claude tab-title <state>`** — hook ハンドラ。stdin の `cwd` から repo 名を取り `terminalSequence` JSON（OSC 0）を出力。
- **settings.json への hook 注入** は冪等（マーカー方式で 6 イベントを除去→再追加）。`hooks[].command` を持たないエントリ（`type:"agent"` の airis-verify Stop hook 等）は保全。
- 手書きの `warp-tab-title.sh` hook は setup 時に自動移行。`airis claude uninstall` で除去。
- pre-commit hook によりバージョン自動 bump（3.19.7 → 3.19.8）。

## テスト

- `cargo build` / `cargo clippy` クリーン
- `cargo test` — 392 件パス（新規 tab-title テスト 10 本: 冪等性・agent hook 保全・レガシー移行・破損 settings.json・ユーザー hook 保全）
- 手動: `echo '{"cwd":"..."}' | airis claude tab-title running` で `terminalSequence` 出力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)