### PR TITLE
fix(guards): honor warn/off guard level instead of always enforcing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.19.8"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.20.0"
+version = "3.20.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.20.0"
+version = "3.20.1"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.19.8"
+version = "3.20.0"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/claude_setup/tests.rs
+++ b/src/commands/claude_setup/tests.rs
@@ -533,7 +533,10 @@ fn test_tab_title_preserves_unrelated_user_hooks() {
     mutate(&mut settings, "/bin/airis", true);
     let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
     assert_eq!(pre.len(), 2, "user hook + injected waiting hook");
-    assert!(pre.iter().any(|e| e["hooks"][0]["command"] == "my-custom-hook.sh"));
+    assert!(
+        pre.iter()
+            .any(|e| e["hooks"][0]["command"] == "my-custom-hook.sh")
+    );
 
     mutate(&mut settings, "/bin/airis", false);
     let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
@@ -544,7 +547,12 @@ fn test_tab_title_preserves_unrelated_user_hooks() {
 #[test]
 fn test_tab_title_apply_writes_file_and_counts() {
     let claude = tempfile::tempdir().unwrap();
-    let result = apply(claude.path(), "/bin/airis", &TerminalTitleSection::default()).unwrap();
+    let result = apply(
+        claude.path(),
+        "/bin/airis",
+        &TerminalTitleSection::default(),
+    )
+    .unwrap();
     assert_eq!(result.injected, 6);
     assert!(claude.path().join("settings.json").exists());
     assert_eq!(count_managed_entries(claude.path()), 6);
@@ -562,7 +570,12 @@ fn test_tab_title_apply_handles_corrupt_settings() {
     let claude = tempfile::tempdir().unwrap();
     fs::write(claude.path().join("settings.json"), "{ not json").unwrap();
     // Corrupt settings.json is skipped with a warning, never panics or errors.
-    let result = apply(claude.path(), "/bin/airis", &TerminalTitleSection::default()).unwrap();
+    let result = apply(
+        claude.path(),
+        "/bin/airis",
+        &TerminalTitleSection::default(),
+    )
+    .unwrap();
     assert_eq!(result.injected, 0);
 }
 

--- a/src/commands/guards/scripts.rs
+++ b/src/commands/guards/scripts.rs
@@ -93,7 +93,16 @@ fi
 
 # 2. Airis Context detection & Smart Proxy
 if find_airis_context >/dev/null; then
-    # We are in an airis docker-first project. Route to Docker via airis exec.
+    # We are in an airis docker-first project. Behavior depends on guard level.
+    if [[ "$LEVEL" != "enforce" ]]; then
+        # warn / off: never block. warn additionally notifies the user.
+        if [[ "$LEVEL" == "warn" ]]; then
+            echo "⚠️  AIRIS: '{cmd}' is running on the host inside an airis workspace (guard level: warn)." >&2
+            echo "   Docker-first recommends: airis exec '{cmd}' ..." >&2
+        fi
+        if [[ -n "$REAL_CMD" ]]; then exec "$REAL_CMD" "$@"; else exit 127; fi
+    fi
+    # enforce: route to Docker via airis exec.
     if command -v airis &>/dev/null; then
         # Non-interactive (no TTY on stdout): disable auto-up so that background
         # scripts such as statusline commands and hooks don't trigger a full

--- a/src/commands/guards/tests.rs
+++ b/src/commands/guards/tests.rs
@@ -188,6 +188,73 @@ fn enforce_passes_through_outside_airis_context() {
     );
 }
 
+#[test]
+fn generated_script_branches_on_guard_level() {
+    // Regression: the `LEVEL` variable used to be dead code — every level
+    // behaved like Enforce. The generated script must actually branch on it.
+    let dir = tempfile::tempdir().unwrap();
+    install_global_guard(dir.path(), "pnpm", GuardLevel::Warn).unwrap();
+
+    let content = fs::read_to_string(dir.path().join("pnpm")).unwrap();
+    assert!(
+        content.contains("LEVEL=\"warn\""),
+        "guard level must be embedded in the script. Got:\n{content}"
+    );
+    assert!(
+        content.contains("if [[ \"$LEVEL\" != \"enforce\" ]]"),
+        "script must branch on $LEVEL so warn/off do not route to Docker. Got:\n{content}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn warn_level_passes_through_inside_workspace() {
+    // Regression: a `warn`-level guard must notify but proceed with the host
+    // command — it must NOT route to `airis exec`. We prove this with a mock
+    // `airis` that always fails: if the guard wrongly routed to it the shim
+    // would exit non-zero. With warn it execs the real `true` and exits 0.
+    let bin_dir = tempfile::tempdir().unwrap();
+    install_global_guard(bin_dir.path(), "true", GuardLevel::Warn).unwrap();
+
+    let tmp_home = tempfile::tempdir().unwrap();
+    let work_dir = tmp_home.path().join("work");
+    fs::create_dir_all(&work_dir).unwrap();
+    // Plant .airis/ so the guard would route to Docker under Enforce.
+    fs::create_dir_all(work_dir.join(".airis")).unwrap();
+
+    // Mock `airis` that always fails — must not be invoked under warn.
+    let mock_airis = tmp_home.path().join("airis");
+    fs::write(&mock_airis, "#!/usr/bin/env bash\nexit 1\n").unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&mock_airis, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let script = bin_dir.path().join("true");
+    let path = format!("{}:/usr/bin:/bin", tmp_home.path().display());
+    let output = Command::new("bash")
+        .arg(&script)
+        .current_dir(&work_dir)
+        .env_clear()
+        .env("HOME", tmp_home.path())
+        .env("PATH", &path)
+        .output()
+        .expect("bash must be available");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "warn level must exec the real command (true), not route to airis.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("guard level: warn"),
+        "warn level must notify the user on stderr. Got stderr:\n{stderr}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn airis_bypass_skips_guard() {


### PR DESCRIPTION
## 問題

生成される guard スクリプトは `LEVEL="<level>"` を埋め込むだけで本体から一切参照しておらず、**全ての guard が level に関係なく Enforce 相当の挙動**になっていた。

結果として `warn` レベルのコマンド（および「警告のみ・ブロックしない」と説明されている `Permissive` プリセット全体）が、workspace 内でホストコマンドを `airis exec` 経由で Docker に強制ルーティングしていた。`Off` はスクリプト未インストールで偶然動作、壊れていたのは `Warn` のみ。

## 修正

`scripts.rs` の airis-context 検出ブロックを `$LEVEL` で分岐:

- `enforce` — 従来どおり `airis exec` で Docker へルーティング
- `warn` — stderr に通知してホストの実コマンドを実行（ブロックしない）
- `off` — 無言でパススルー

## テスト

- `warn_level_passes_through_inside_workspace` — workspace 内で warn レベルが `airis` を呼ばず実コマンドを実行することを検証（常に失敗する mock `airis` を使い、誤ってルーティングされたら exit≠0 で検出）
- `generated_script_branches_on_guard_level` — テンプレートが `$LEVEL` で分岐していることを検証
- 修正前に新テストが FAIL することを確認済み。修正後 `cargo test --lib` 全 372 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)