### PR TITLE
feat(gen): add [root] section support to manifest.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.20.2"
+version = "3.20.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.20.2"
+version = "3.20.3"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/manifest/schema.rs
+++ b/src/manifest/schema.rs
@@ -1746,12 +1746,31 @@ pub struct ExternalServiceConfig {
 // v2: Root Section (replaces packages.root in v1)
 // =============================================================================
 
+/// Root-level package.json configuration.
+///
+/// Declared in `manifest.toml` as `[root]`. When `airis gen` runs, these values
+/// are merged on top of any `[packages.root]` declarations and written into the
+/// workspace-root `package.json`.
+///
+/// Example:
+/// ```toml
+/// [root]
+/// [root.devDependencies]
+/// vitest            = "catalog:"
+/// jsdom             = "catalog:"
+/// "@vitest/coverage-v8" = "catalog:"
+///
+/// [root.scripts]
+/// test = "vitest run"
+/// ```
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct RootSection {
     #[serde(default)]
     pub engines: IndexMap<String, String>,
     #[serde(default)]
     pub scripts: IndexMap<String, String>,
+    #[serde(default)]
+    pub dependencies: IndexMap<String, String>,
     #[serde(rename = "devDependencies", default)]
     pub dev_dependencies: IndexMap<String, String>,
 }

--- a/src/manifest/tests.rs
+++ b/src/manifest/tests.rs
@@ -958,3 +958,149 @@ id = "test"
         "got: {msg}"
     );
 }
+
+// =============================================================================
+// [root] section tests
+// =============================================================================
+
+#[test]
+fn test_root_section_absent_defaults_to_none() {
+    let manifest = load_from_str(&minimal_manifest()).unwrap();
+    assert!(manifest.root.is_none());
+}
+
+#[test]
+fn test_root_section_parses_dev_dependencies() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[root.devDependencies]
+vitest                = "catalog:"
+jsdom                 = "catalog:"
+"@vitest/coverage-v8" = "catalog:"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let root = manifest
+        .root
+        .as_ref()
+        .expect("[root] section must be parsed");
+    assert_eq!(
+        root.dev_dependencies.get("vitest").map(String::as_str),
+        Some("catalog:")
+    );
+    assert_eq!(
+        root.dev_dependencies.get("jsdom").map(String::as_str),
+        Some("catalog:")
+    );
+    assert_eq!(
+        root.dev_dependencies
+            .get("@vitest/coverage-v8")
+            .map(String::as_str),
+        Some("catalog:")
+    );
+}
+
+#[test]
+fn test_root_section_parses_dependencies() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[root.dependencies]
+"some-runtime-dep" = "^1.0.0"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let root = manifest
+        .root
+        .as_ref()
+        .expect("[root] section must be parsed");
+    assert_eq!(
+        root.dependencies
+            .get("some-runtime-dep")
+            .map(String::as_str),
+        Some("^1.0.0")
+    );
+    assert!(root.dev_dependencies.is_empty());
+}
+
+#[test]
+fn test_root_section_parses_scripts() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[root.scripts]
+test = "vitest run"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let root = manifest
+        .root
+        .as_ref()
+        .expect("[root] section must be parsed");
+    assert_eq!(
+        root.scripts.get("test").map(String::as_str),
+        Some("vitest run")
+    );
+}
+
+#[test]
+fn test_root_section_full_config() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[root.devDependencies]
+vitest = "catalog:"
+
+[root.dependencies]
+"some-lib" = "^2.0.0"
+
+[root.scripts]
+test  = "vitest run"
+build = "tsc -b"
+
+[root.engines]
+node = ">=22"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let root = manifest
+        .root
+        .as_ref()
+        .expect("[root] section must be parsed");
+    assert_eq!(root.dev_dependencies.len(), 1);
+    assert_eq!(root.dependencies.len(), 1);
+    assert_eq!(root.scripts.len(), 2);
+    assert_eq!(root.engines.get("node").map(String::as_str), Some(">=22"));
+}
+
+#[test]
+fn test_root_section_round_trips_through_toml() {
+    let toml = r#"
+version = 1
+[project]
+id = "test"
+
+[root.devDependencies]
+vitest = "catalog:"
+
+[root.scripts]
+test = "vitest run"
+"#;
+    let manifest = load_from_str(toml).unwrap();
+    let serialized = toml::to_string(&manifest).unwrap();
+    let reparsed: Manifest = toml::from_str(&serialized).unwrap();
+    let root = reparsed.root.as_ref().expect("[root] must round-trip");
+    assert_eq!(
+        root.dev_dependencies.get("vitest").map(String::as_str),
+        Some("catalog:")
+    );
+    assert_eq!(
+        root.scripts.get("test").map(String::as_str),
+        Some("vitest run")
+    );
+}

--- a/src/templates/package.rs
+++ b/src/templates/package.rs
@@ -39,38 +39,63 @@ impl TemplateEngine {
             );
         }
 
-        // Add root dependencies from manifest.packages.root
+        // Add root dependencies from manifest.packages.root (v1) and manifest.root (v2).
+        // manifest.root values are merged on top of manifest.packages.root so that
+        // [root] declarations in manifest.toml always win.
         let root_pkg = &manifest.packages.root;
 
-        if !root_pkg.scripts.is_empty() {
+        // Merge scripts: packages.root first, then [root] overrides.
+        let mut merged_scripts = root_pkg.scripts.clone();
+        if let Some(ref root) = manifest.root {
+            for (k, v) in &root.scripts {
+                merged_scripts.insert(k.clone(), v.clone());
+            }
+        }
+        if !merged_scripts.is_empty() {
             obj.insert(
                 "scripts".to_string(),
-                serde_json::to_value(&root_pkg.scripts)?,
+                serde_json::to_value(&merged_scripts)?,
             );
         }
 
-        if !root_pkg.dependencies.is_empty() {
+        // Merge dependencies: packages.root first, then [root] overrides.
+        let mut merged_deps = root_pkg.dependencies.clone();
+        if let Some(ref root) = manifest.root {
+            for (k, v) in &root.dependencies {
+                merged_deps.insert(k.clone(), v.clone());
+            }
+        }
+        if !merged_deps.is_empty() {
             let mut deps = serde_json::Map::new();
-            for (k, v) in &root_pkg.dependencies {
+            for (k, v) in &merged_deps {
                 // If it's in the manifest catalog, use "catalog:"
-                let version = if resolved_catalog.contains_key(k) {
-                    "catalog:".to_string()
-                } else {
-                    v.clone()
-                };
+                let version =
+                    if resolved_catalog.contains_key(k) || v == "catalog" || v == "catalog:" {
+                        "catalog:".to_string()
+                    } else {
+                        v.clone()
+                    };
                 deps.insert(k.clone(), serde_json::json!(version));
             }
             obj.insert("dependencies".to_string(), serde_json::Value::Object(deps));
         }
 
-        if !root_pkg.dev_dependencies.is_empty() {
+        // Merge devDependencies: packages.root first, then [root] overrides.
+        let mut merged_dev_deps = root_pkg.dev_dependencies.clone();
+        if let Some(ref root) = manifest.root {
+            for (k, v) in &root.dev_dependencies {
+                merged_dev_deps.insert(k.clone(), v.clone());
+            }
+        }
+        if !merged_dev_deps.is_empty() {
             let mut dev_deps = serde_json::Map::new();
-            for (k, v) in &root_pkg.dev_dependencies {
-                let version = if resolved_catalog.contains_key(k) {
-                    "catalog:".to_string()
-                } else {
-                    v.clone()
-                };
+            for (k, v) in &merged_dev_deps {
+                let version =
+                    if resolved_catalog.contains_key(k) || v == "catalog" || v == "catalog:" {
+                        "catalog:".to_string()
+                    } else {
+                        v.clone()
+                    };
                 dev_deps.insert(k.clone(), serde_json::json!(version));
             }
             obj.insert(
@@ -79,10 +104,17 @@ impl TemplateEngine {
             );
         }
 
-        if !root_pkg.engines.is_empty() {
+        // Merge engines: packages.root first, then [root] overrides.
+        let mut merged_engines = root_pkg.engines.clone();
+        if let Some(ref root) = manifest.root {
+            for (k, v) in &root.engines {
+                merged_engines.insert(k.clone(), v.clone());
+            }
+        }
+        if !merged_engines.is_empty() {
             obj.insert(
                 "engines".to_string(),
-                serde_json::to_value(&root_pkg.engines)?,
+                serde_json::to_value(&merged_engines)?,
             );
         }
 

--- a/src/templates/tests.rs
+++ b/src/templates/tests.rs
@@ -1,4 +1,6 @@
 use crate::manifest::Manifest;
+use crate::templates::TemplateEngine;
+use indexmap::IndexMap;
 
 #[test]
 fn test_glob_expansion_adds_products_workspaces() {
@@ -96,4 +98,278 @@ fn test_profile_effective_role() {
         ..Default::default()
     };
     assert_eq!(custom.effective_role("stg"), "production");
+}
+
+// =============================================================================
+// render_package_json — [root] section integration
+// =============================================================================
+
+/// Helper: render root package.json from a TOML string and return parsed JSON.
+fn render_pkg(toml_str: &str, catalog: &IndexMap<String, String>) -> serde_json::Value {
+    let manifest: Manifest = toml::from_str(toml_str).expect("valid toml");
+    let engine = TemplateEngine::new().expect("TemplateEngine::new");
+    let content = engine
+        .render_package_json(&manifest, catalog)
+        .expect("render_package_json must succeed");
+    serde_json::from_str(&content).expect("valid JSON output")
+}
+
+#[test]
+fn test_render_package_json_root_dev_deps_appear_in_output() {
+    let toml_str = r#"
+version = 1
+[project]
+id = "test"
+
+[workspace]
+name = "my-workspace"
+
+[root.devDependencies]
+vitest                = "catalog:"
+jsdom                 = "catalog:"
+"@vitest/coverage-v8" = "catalog:"
+"#;
+    let catalog = IndexMap::new();
+    let json = render_pkg(toml_str, &catalog);
+    let dev_deps = json["devDependencies"]
+        .as_object()
+        .expect("devDependencies must exist");
+    assert!(
+        dev_deps.contains_key("vitest"),
+        "vitest must be in devDependencies"
+    );
+    assert_eq!(dev_deps["vitest"], "catalog:");
+    assert!(
+        dev_deps.contains_key("jsdom"),
+        "jsdom must be in devDependencies"
+    );
+    assert!(
+        dev_deps.contains_key("@vitest/coverage-v8"),
+        "@vitest/coverage-v8 must be in devDependencies"
+    );
+}
+
+#[test]
+fn test_render_package_json_root_scripts_appear_in_output() {
+    let toml_str = r#"
+version = 1
+[project]
+id = "test"
+
+[workspace]
+name = "my-workspace"
+
+[root.scripts]
+test = "vitest run"
+"#;
+    let catalog = IndexMap::new();
+    let json = render_pkg(toml_str, &catalog);
+    let scripts = json["scripts"].as_object().expect("scripts must exist");
+    assert_eq!(scripts["test"], "vitest run");
+}
+
+#[test]
+fn test_render_package_json_root_deps_use_catalog_when_in_catalog() {
+    // [root.devDependencies] versions referencing a package present in [packages.catalog]
+    // must be normalised to "catalog:" by the generator.
+    let toml_str = r#"
+version = 1
+[project]
+id = "test"
+
+[workspace]
+name = "my-workspace"
+
+[root.devDependencies]
+vitest = "^3.0.0"
+jsdom  = "^26.0.0"
+"#;
+    let mut catalog = IndexMap::new();
+    catalog.insert("vitest".to_string(), "^3.0.0".to_string());
+    // jsdom is NOT in the catalog — should keep the explicit version.
+    let json = render_pkg(toml_str, &catalog);
+    let dev_deps = json["devDependencies"]
+        .as_object()
+        .expect("devDependencies must exist");
+    assert_eq!(
+        dev_deps["vitest"], "catalog:",
+        "catalog entry must become 'catalog:'"
+    );
+    assert_eq!(
+        dev_deps["jsdom"], "^26.0.0",
+        "non-catalog entry must keep explicit version"
+    );
+}
+
+#[test]
+fn test_render_package_json_root_overrides_packages_root_scripts() {
+    // [root.scripts] must override same-name entries from [packages.root.scripts].
+    let toml_str = r#"
+version = 1
+[project]
+id = "test"
+
+[workspace]
+name = "my-workspace"
+
+[packages.root.scripts]
+test = "jest"
+build = "tsc"
+
+[root.scripts]
+test = "vitest run"
+"#;
+    let catalog = IndexMap::new();
+    let json = render_pkg(toml_str, &catalog);
+    let scripts = json["scripts"].as_object().expect("scripts must exist");
+    // [root.scripts] wins over [packages.root.scripts] for "test".
+    assert_eq!(
+        scripts["test"], "vitest run",
+        "[root.scripts] must override [packages.root.scripts]"
+    );
+    // [packages.root.scripts] entry not overridden by [root] must be preserved.
+    assert_eq!(
+        scripts["build"], "tsc",
+        "non-conflicting [packages.root.scripts] entry must survive"
+    );
+}
+
+#[test]
+fn test_render_package_json_root_overrides_packages_root_dev_deps() {
+    // [root.devDependencies] must override same-name entries from [packages.root.devDependencies].
+    let toml_str = r#"
+version = 1
+[project]
+id = "test"
+
+[workspace]
+name = "my-workspace"
+
+[packages.root.devDependencies]
+turbo = "^2.0.0"
+vitest = "^2.0.0"
+
+[root.devDependencies]
+vitest = "catalog:"
+"#;
+    let catalog = IndexMap::new();
+    let json = render_pkg(toml_str, &catalog);
+    let dev_deps = json["devDependencies"]
+        .as_object()
+        .expect("devDependencies must exist");
+    // [root.devDependencies] wins over [packages.root.devDependencies] for "vitest".
+    assert_eq!(
+        dev_deps["vitest"], "catalog:",
+        "[root.devDependencies] must override [packages.root.devDependencies]"
+    );
+    // Non-conflicting entry from packages.root must survive.
+    assert_eq!(
+        dev_deps["turbo"], "^2.0.0",
+        "non-conflicting [packages.root.devDependencies] entry must survive"
+    );
+}
+
+#[test]
+fn test_render_package_json_no_root_section_preserves_packages_root() {
+    // When [root] is absent the existing [packages.root] behavior is unchanged.
+    let toml_str = r#"
+version = 1
+[project]
+id = "test"
+
+[workspace]
+name = "my-workspace"
+
+[packages.root.devDependencies]
+turbo = "catalog:"
+typescript = "catalog:"
+
+[packages.root.scripts]
+build = "turbo build"
+"#;
+    let mut catalog = IndexMap::new();
+    catalog.insert("turbo".to_string(), "^2.0.0".to_string());
+    catalog.insert("typescript".to_string(), "latest".to_string());
+    let json = render_pkg(toml_str, &catalog);
+    let dev_deps = json["devDependencies"]
+        .as_object()
+        .expect("devDependencies must exist");
+    assert_eq!(dev_deps["turbo"], "catalog:");
+    assert_eq!(dev_deps["typescript"], "catalog:");
+    let scripts = json["scripts"].as_object().expect("scripts must exist");
+    assert_eq!(scripts["build"], "turbo build");
+}
+
+#[test]
+fn test_render_package_json_agiletec_like_root_section() {
+    // Simulate the agiletec manifest.toml [root] section added by PR #435.
+    // After this change, airis gen must include vitest/jsdom/@vitest/coverage-v8
+    // in the generated root package.json devDependencies.
+    let toml_str = r#"
+version = 1
+[project]
+id = "agiletec"
+
+[workspace]
+name = "agiletec"
+scope = "@agiletec"
+package_manager = "pnpm@10.33.0"
+image = "node:24-bookworm"
+
+[packages.catalog]
+vitest             = "^3.0.0"
+jsdom              = "^26.0.0"
+"@vitest/coverage-v8" = "^3.0.0"
+
+[packages.root.devDependencies]
+turbo = "^2.9.6"
+
+[root.devDependencies]
+vitest                = "catalog:"
+jsdom                 = "catalog:"
+"@vitest/coverage-v8" = "catalog:"
+
+[root.scripts]
+test = "vitest run"
+"#;
+    let mut catalog = IndexMap::new();
+    catalog.insert("vitest".to_string(), "^3.0.0".to_string());
+    catalog.insert("jsdom".to_string(), "^26.0.0".to_string());
+    catalog.insert("@vitest/coverage-v8".to_string(), "^3.0.0".to_string());
+
+    let json = render_pkg(toml_str, &catalog);
+
+    // vitest, jsdom, and @vitest/coverage-v8 must appear in devDependencies.
+    let dev_deps = json["devDependencies"]
+        .as_object()
+        .expect("devDependencies must exist");
+    assert!(
+        dev_deps.contains_key("vitest"),
+        "vitest must survive airis gen"
+    );
+    assert!(
+        dev_deps.contains_key("jsdom"),
+        "jsdom must survive airis gen"
+    );
+    assert!(
+        dev_deps.contains_key("@vitest/coverage-v8"),
+        "@vitest/coverage-v8 must survive airis gen"
+    );
+    // All three are in catalog — must be normalised to "catalog:".
+    assert_eq!(dev_deps["vitest"], "catalog:");
+    assert_eq!(dev_deps["jsdom"], "catalog:");
+    assert_eq!(dev_deps["@vitest/coverage-v8"], "catalog:");
+
+    // The pre-existing turbo entry from [packages.root.devDependencies] must survive.
+    assert!(
+        dev_deps.contains_key("turbo"),
+        "turbo from packages.root must survive"
+    );
+
+    // test script must appear.
+    let scripts = json["scripts"].as_object().expect("scripts must exist");
+    assert_eq!(
+        scripts["test"], "vitest run",
+        "test script must survive airis gen"
+    );
 }


### PR DESCRIPTION
## Summary

- `manifest.toml` の `[root]` セクションを `Manifest` struct に正式に追加（`dependencies` フィールドを `RootSection` に追加）
- `render_package_json` が `[root]` の値を `[packages.root]` の上にマージするように修正（`[root]` が常に優先）
- バージョンを `catalog:` に正規化するロジックも同様に適用
- パース・ラウンドトリップテストを `src/manifest/tests.rs` に追加
- `render_package_json` の統合テストを `src/templates/tests.rs` に追加（agiletecのリアルなフィクスチャを含む）

## Background

agiletec PR #435 がルート `package.json` に `vitest` / `jsdom` / `@vitest/coverage-v8` を手動追加した。PR descriptionに記載の通り、このまま `airis gen` を実行すると `[root]` セクションを認識しないため、これらのエントリが**サイレントに削除**される時限爆弾になっていた。

## What `[root]` now supports

```toml
[root.devDependencies]
vitest                = "catalog:"
jsdom                 = "catalog:"
"@vitest/coverage-v8" = "catalog:"

[root.dependencies]
some-runtime-dep = "^1.0.0"

[root.scripts]
test = "vitest run"

[root.engines]
node = ">=22"
```

- `devDependencies` — カタログ内のパッケージは自動的に `"catalog:"` に正規化
- `dependencies` — 同上
- `scripts` — `[packages.root.scripts]` の上書き可
- `engines` — `[packages.root.engines]` の上書き可
- `[packages.root]` との関係: `[root]` が同名キーで上書き、非競合エントリは保持

## agiletec manifest.toml の round-trip 検証

テスト `test_render_package_json_agiletec_like_root_section` がagiletecの `[root]` セクション相当の入力で `airis gen` をシミュレート:

- `vitest` / `jsdom` / `@vitest/coverage-v8` がすべて `devDependencies` に存在することを確認
- カタログ内エントリが `"catalog:"` に正規化されることを確認
- `test: "vitest run"` スクリプトが保持されることを確認
- `[packages.root.devDependencies]` の既存エントリ（`turbo`）も保持されることを確認

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo test` — 387 unit tests + 20 integration tests, all pass (0 failed)
- [x] バージョン自動バンプ: 3.20.2 → 3.20.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)