### PR TITLE
fix(generate): round-trip compose GPU reservations & YAML merge keys

### DIFF
--- a/src/commands/generate/compose_gen.rs
+++ b/src/commands/generate/compose_gen.rs
@@ -91,14 +91,22 @@ struct ComposeDeploy {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 struct ComposeResources {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    reservations: Vec<ComposeReservation>,
+    /// A single map in the Compose spec (`{ cpus, memory, devices, ... }`),
+    /// not a sequence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reservations: Option<ComposeReservation>,
+    /// Catch-all for unmodeled fields such as `limits`.
+    #[serde(flatten)]
+    extra: IndexMap<String, serde_yaml_ng::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 struct ComposeReservation {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     devices: Vec<ComposeDevice>,
+    /// Catch-all for unmodeled fields such as `cpus`, `memory`, `generic_resources`.
+    #[serde(flatten)]
+    extra: IndexMap<String, serde_yaml_ng::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
@@ -353,13 +361,15 @@ fn build_app_service(
     let deploy = if use_gpu_override {
         Some(ComposeDeploy {
             resources: Some(ComposeResources {
-                reservations: vec![ComposeReservation {
+                reservations: Some(ComposeReservation {
                     devices: vec![ComposeDevice {
                         driver: Some("nvidia".to_string()),
                         count: Some(serde_json::json!("all")),
                         capabilities: vec!["gpu".to_string()],
                     }],
-                }],
+                    ..Default::default()
+                }),
+                ..Default::default()
             }),
         })
     } else {
@@ -560,5 +570,33 @@ mod tests {
                 .iter()
                 .any(|v| v.starts_with("myproj-api-next:"))
         );
+    }
+
+    #[test]
+    fn merge_parses_gpu_resource_reservations() {
+        // Regression: `deploy.resources.reservations` is a map in the Compose
+        // spec, not a sequence. Parsing a GPU service must not fail.
+        let dir = tempdir().unwrap();
+        let existing_path = dir.path().join("compose.yaml");
+        fs::write(
+            &existing_path,
+            r#"services:
+  gpu-svc:
+    image: cuda:12
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+"#,
+        )
+        .unwrap();
+
+        let merged = merge_with_existing(ComposeFile::default(), &existing_path).unwrap();
+        assert!(merged.services.contains_key("gpu-svc"));
     }
 }

--- a/src/commands/generate/compose_gen.rs
+++ b/src/commands/generate/compose_gen.rs
@@ -391,6 +391,45 @@ fn build_app_service(
     }
 }
 
+/// Resolve YAML merge keys (`<<`) throughout a value tree.
+///
+/// Compose files commonly DRY up shared config with anchors and `<<` merge
+/// keys (e.g. `<<: *defaults`). `serde_yaml_ng` resolves anchors but leaves
+/// `<<` as a literal key, so merges must be applied before deserializing into
+/// the typed model. Keys already present on the host mapping win over merged
+/// ones, matching the YAML merge-key spec.
+fn resolve_merge_keys(value: &mut serde_yaml_ng::Value) {
+    use serde_yaml_ng::Value;
+    match value {
+        Value::Mapping(map) => {
+            for (_, child) in map.iter_mut() {
+                resolve_merge_keys(child);
+            }
+            if let Some(merge) = map.remove("<<") {
+                let sources = match merge {
+                    Value::Sequence(seq) => seq,
+                    single => vec![single],
+                };
+                for source in sources {
+                    if let Value::Mapping(source_map) = source {
+                        for (key, val) in source_map {
+                            if !map.contains_key(&key) {
+                                map.insert(key, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Value::Sequence(seq) => {
+            for item in seq.iter_mut() {
+                resolve_merge_keys(item);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Merge generated services with the existing compose file:
 /// - Existing services with `x-airis-managed: true` are replaced by the new
 ///   generated version (or removed if no longer generated).
@@ -403,7 +442,10 @@ fn merge_with_existing(generated: ComposeFile, existing_path: &Path) -> Result<C
     let existing: ComposeFile = if raw.trim().is_empty() {
         ComposeFile::default()
     } else {
-        serde_yaml_ng::from_str(&raw)
+        let mut value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&raw)
+            .with_context(|| format!("failed to parse {} as YAML", existing_path.display()))?;
+        resolve_merge_keys(&mut value);
+        serde_yaml_ng::from_value(value)
             .with_context(|| format!("failed to parse {} as YAML", existing_path.display()))?
     };
 
@@ -598,5 +640,41 @@ mod tests {
 
         let merged = merge_with_existing(ComposeFile::default(), &existing_path).unwrap();
         assert!(merged.services.contains_key("gpu-svc"));
+    }
+
+    #[test]
+    fn merge_resolves_yaml_merge_keys() {
+        // Regression: compose files DRY up config with YAML anchors and `<<`
+        // merge keys, including nested ones (e.g. inside `environment`).
+        let dir = tempdir().unwrap();
+        let existing_path = dir.path().join("compose.yaml");
+        fs::write(
+            &existing_path,
+            r#"x-base: &base
+  restart: always
+  networks: [traefik]
+x-env: &env
+  NODE_ENV: production
+services:
+  web:
+    <<: *base
+    image: nginx
+    environment:
+      <<: *env
+      EXTRA: "1"
+"#,
+        )
+        .unwrap();
+
+        let merged = merge_with_existing(ComposeFile::default(), &existing_path).unwrap();
+        let web = &merged.services["web"];
+        assert_eq!(web.restart.as_deref(), Some("always"));
+        assert_eq!(web.networks, vec!["traefik"]);
+        assert_eq!(web.image.as_deref(), Some("nginx"));
+        assert_eq!(
+            web.environment.get("NODE_ENV").map(String::as_str),
+            Some("production")
+        );
+        assert_eq!(web.environment.get("EXTRA").map(String::as_str), Some("1"));
     }
 }


### PR DESCRIPTION
## Summary

`airis gen` failed to read back any `compose.yaml` containing a GPU device reservation or YAML merge keys. Two related fixes to the compose round-trip parser.

- **`reservations` as a map** — the Docker Compose spec defines `deploy.resources.reservations` as a single map (`{ cpus, memory, devices, ... }`), not a sequence. The previous `Vec<ComposeReservation>` model made `airis gen` fail with `invalid type: map, expected a sequence`. Changed to `Option<ComposeReservation>` with flatten catch-alls on `ComposeResources` / `ComposeReservation` so unmodeled fields round-trip instead of being dropped.
- **YAML merge keys** — resolve `<<` merge keys when parsing `compose.yaml`, with explicit keys winning over merged-in keys per the YAML merge-key spec.

## Notes

Branch rebased onto current `main` (was 10 commits behind). The only rebase conflicts were the `Cargo.toml` / `Cargo.lock` version line — resolved to keep `main`'s `3.20.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)