### PR TITLE
ci: auto-enable auto-merge on PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,66 @@
+name: Auto-merge
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (merge commit)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const nodeId = pr.data.node_id;
+            const mutation = `
+              mutation EnableAutoMerge($id: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $id,
+                  mergeMethod: MERGE
+                }) {
+                  pullRequest { number autoMergeRequest { mergeMethod } }
+                }
+              }
+            `;
+            // Retry with exponential backoff.
+            // GitHub rejects with UNPROCESSABLE in two cases:
+            //   1. PR was just opened and checks haven't started yet ("unstable")
+            //   2. All required checks already passed before this mutation ran
+            //      (breaking change introduced ~March 2026)
+            // In case 2 GitHub will auto-merge without this mutation, so we
+            // treat both as non-fatal and retry until the window opens or give up.
+            const maxAttempts = 6;
+            for (let i = 0; i < maxAttempts; i++) {
+              try {
+                await github.graphql(mutation, { id: nodeId });
+                console.log('Auto-merge enabled.');
+                break;
+              } catch (e) {
+                const msg = e.message ?? '';
+                const isUnstable = msg.includes('unstable') ||
+                  (e.errors ?? []).some(err => (err.message ?? '').includes('unstable'));
+                const alreadyEnabled = msg.includes('already enabled') ||
+                  (e.errors ?? []).some(err => (err.message ?? '').includes('already enabled'));
+                if (alreadyEnabled) {
+                  console.log('Auto-merge already enabled, skipping.');
+                  break;
+                }
+                if (isUnstable && i < maxAttempts - 1) {
+                  const delay = Math.min(5000 * 2 ** i, 30000);
+                  console.log(`PR unstable (attempt ${i + 1}/${maxAttempts}), retrying in ${delay}ms…`);
+                  await new Promise(r => setTimeout(r, delay));
+                } else {
+                  throw e;
+                }
+              }
+            }


### PR DESCRIPTION
Adds the same `auto-merge.yml` workflow `airis-studio` already uses: on every PR (`opened`/`reopened`/`synchronize`) it enables GitHub auto-merge (merge commit) via `actions/github-script`, with exponential-backoff retry for the "unstable" / "checks already passed" race windows.

Combined with `allow_auto_merge` (now enabled) and `delete_branch_on_merge` (already on), PRs merge themselves once CI is green and the remote branch is deleted automatically. Local worktree/branch cleanup is handled separately by a `git-worktree-sweep` launchd job on the Mac.

Public repo → `runs-on: ubuntu-latest` (no ARC container needed, unlike airis-studio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)