### PR TITLE
fix(ui): legacy tab-title shim delegates to the script (un-freeze stale sessions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "airis-workspace"
-version = "3.21.0"
+version = "3.21.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "airis-workspace"
-version = "3.21.0"
+version = "3.21.1"
 edition = "2024"
 authors = ["kazuki <kazuki.nakai@agiletec.net>"]
 description = "Docker-first monorepo workspace manager for rapid prototyping"

--- a/src/commands/ui/mod.rs
+++ b/src/commands/ui/mod.rs
@@ -8,7 +8,7 @@
 // them.
 
 use std::fs;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -229,6 +229,51 @@ pub fn status() -> Result<()> {
         tt.enabled, tt.running, tt.waiting, idle
     );
 
+    Ok(())
+}
+
+/// Legacy `airis claude tab-title <state>` shim handler.
+///
+/// A Claude Code session started before the `airis ui` migration keeps the
+/// old hook wiring in its startup snapshot and still calls this command. A
+/// plain no-op would leave that session's tab emoji frozen, so bridge the
+/// call to the installed `airis-tab-title.sh` script instead — the emoji then
+/// updates without restarting the session. Always succeeds: a failing
+/// `UserPromptSubmit` hook would block the whole session.
+pub fn legacy_tab_title_shim(args: &[String]) -> Result<()> {
+    // Drain the hook payload from stdin; it is forwarded to the script.
+    let mut payload = String::new();
+    let _ = std::io::stdin().read_to_string(&mut payload);
+
+    let Ok(home) = claude_home() else {
+        return Ok(());
+    };
+    let script = home.join(TAB_TITLE_REL);
+    if !script.exists() {
+        // Pre-`airis ui install`: nothing to delegate to. Stay harmless.
+        return Ok(());
+    }
+
+    let state = args.first().map(String::as_str).unwrap_or("idle");
+    let tt = GlobalConfig::load()
+        .map(|c| c.claude.terminal_title)
+        .unwrap_or_default();
+
+    // Forward to the installed script. stdout is inherited so the script's
+    // terminalSequence JSON reaches Claude Code. Any failure is swallowed —
+    // the shim must never error.
+    if let Ok(mut child) = std::process::Command::new("sh")
+        .arg(&script)
+        .args([state, &tt.running, &tt.waiting, &tt.idle])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::inherit())
+        .spawn()
+    {
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(payload.as_bytes());
+        }
+        let _ = child.wait();
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,15 +77,10 @@ fn dispatch(command: Commands) -> Result<()> {
             ClaudeCommands::Setup => commands::claude_setup::setup_global()?,
             ClaudeCommands::Status => commands::claude_setup::status()?,
             ClaudeCommands::Uninstall => commands::claude_setup::uninstall()?,
-            ClaudeCommands::TabTitle { .. } => {
-                // Legacy shim: a session still wired to the pre-`airis ui`
-                // hook calls `airis claude tab-title <state>`. Drain stdin and
-                // succeed so the stale hook never blocks the session. Real
-                // tab-title work now lives in the `airis ui` shell scripts.
-                use std::io::Read;
-                let mut sink = String::new();
-                let _ = std::io::stdin().read_to_string(&mut sink);
-            }
+            // Legacy shim: a session still wired to the pre-`airis ui` hook
+            // calls `airis claude tab-title <state>`. Bridge it to the
+            // installed script so a stale session's tab emoji still updates.
+            ClaudeCommands::TabTitle { args } => commands::ui::legacy_tab_title_shim(&args)?,
         },
         Commands::Ui { action } => match action {
             UiCommands::Install => commands::ui::install()?,


### PR DESCRIPTION
## 問題

`airis claude tab-title` シムは stdin を読んで exit 0 するだけだった。これで移行前セッションのハードエラーは止まったが、**タブ絵文字が凍結**した — 移行前に起動したセッションは古いフック配線をスナップショットで保持しており、毎イベントで no-op シムを呼ぶため、タイトルが一切更新されない(「絵文字が古いまま残る」)。

## 修正

シムをインストール済みの `airis-tab-title.sh` スクリプトに橋渡しする — フックペイロードと設定済み絵文字を転送。古い配線のままのセッションでも**再起動なしでタブ絵文字がライブ更新**される。引き続き常に exit 0。

## 検証

- `cargo fmt` / `cargo clippy -- -D warnings` / 全テスト (388 + 21 + 10) パス。
- インストール実機確認: `airis claude tab-title running` → `🏃 <repo>`、`idle` → 絵文字なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)