### PR TITLE
fix(compose-gen): drop `.pnpm-store` from pnpm framework isolated_dirs

### DIFF
--- a/src/conventions.rs
+++ b/src/conventions.rs
@@ -131,7 +131,17 @@ pub fn framework_defaults(framework: &str) -> FrameworkDefaults {
                 ("PATH", "/root/.local/share/pnpm:$PATH"),
             ],
             default_scripts: &[],
-            isolated_dirs: &["node_modules", ".pnpm-store"],
+            // `.pnpm-store` is intentionally omitted: mounting it via
+            // `<project>-root-pnpm-store:/app/.pnpm-store` triggers the
+            // global docker-first edit guard (see ~/.claude/rules/docker-first.md)
+            // because `.pnpm-store` is a host-local pnpm path. The global pnpm
+            // store at `/root/.local/share/pnpm/store` (declared in
+            // `global_caches` below) is the canonical content-addressable
+            // location and already survives container recreation via its named
+            // volume. Projects that override `store-dir` in `.npmrc` should
+            // declare that path in their own manifest, not rely on this
+            // default.
+            isolated_dirs: &["node_modules"],
             global_caches: &[("pnpm-store", "/root/.local/share/pnpm/store")],
         },
         "rust" => FrameworkDefaults {


### PR DESCRIPTION
## Summary

- The pnpm framework defaults emitted a `<project>-root-pnpm-store:/app/.pnpm-store` mount as an isolated dir, which trips the Docker-First edit guard (`.pnpm-store` is host-local pnpm convention even when fronted by a named volume)
- Drop `.pnpm-store` from `isolated_dirs`. The global pnpm store mount at `/root/.local/share/pnpm/store` (in `global_caches`) is the canonical content-addressable location and stays
- Discovered while regenerating `compose.yaml` in agiletec: every downstream edit blocked with `BLOCKED: Local pnpm store path in Docker/CI file`

## Test plan
- [x] `cargo build --release` success
- [x] Re-ran `airis gen` in agiletec — `compose.yaml` no longer contains `agiletec-root-pnpm-store:/app/.pnpm-store`
- [x] `airis test/lint/typecheck` in agiletec all pass with the regenerated `compose.yaml` (+ matching `test-runner` workspace mount in agiletec's compose.yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)