### PR TITLE
docs: refocus airis essence to polyglot convention-unification engine

### DIFF
--- a/.claude/rules/generated/PROJECT_RULES.md
+++ b/.claude/rules/generated/PROJECT_RULES.md
@@ -2,7 +2,7 @@
 
 ## Architectural Boundaries
 
-Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygiene Enforcer**. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Its primary value is ensuring a host-hygienic Docker development environment through automated orchestration.
+Airis-workspace is a **polyglot monorepo convention-unification engine**. From a thin `manifest.toml` it keeps a heterogeneous set of repositories consistent: AI adapter files, shared docs, `tsconfig.json`, version scheme, and project scaffolding. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Docker development-environment generation (`compose.yaml`, volume hygiene) is **one module**, serving the subset of repositories that are containerized — not the whole tool.
 
 ## Design Principles
 
@@ -21,7 +21,7 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Non-Negotiables
 
 - For **runtime application** configuration (DB-backed settings, tenant boundaries, feature flags), follow `docs/ai/architecture-invariants.md` alongside this file—`manifest.toml` remains the SoT for workspace tooling, not for per-app DB config.
-- Preserve the Docker-first value proposition of airis. Changes must not weaken command guards or make host-side workflows the default path.
+- For containerized repositories, preserve the integrity of the Docker module (safe `compose.yaml` merge that never destroys user-authored services, volume hygiene). Do not weaken it — but do not impose Docker-first defaults on repositories that don't use it (e.g. Edge/Workers, native desktop apps).
 - Keep `airis gen` and the `workspace_init`/`manifest_apply` MCP tools safe by default. Avoid destructive overwrites unless the feature explicitly supports backups or opt-in replacement.
 - Prefer minimal, reviewable diffs. When changing generation or enforcement logic, document the intended invariant.
 

--- a/.claude/rules/generated/REVIEW.md
+++ b/.claude/rules/generated/REVIEW.md
@@ -2,8 +2,8 @@
 
 ## Primary Checks
 
-- Does the change preserve or strengthen Docker-first enforcement?
-- Does it keep `manifest.toml` authoritative for workspace and guard behavior?
+- Does the change keep the convention-unification engine coherent — AI adapters, docs, `tsconfig.json`, and scaffolding consistent across repos?
+- Does it keep `manifest.toml` authoritative as the thin source of truth, and the Docker module safe for containerized repos?
 - Are generated files or adapters clearly marked and reproducible?
 - Are vendor-specific differences isolated instead of duplicated into shared docs?
 

--- a/.claude/rules/generated/STACK.md
+++ b/.claude/rules/generated/STACK.md
@@ -4,7 +4,7 @@
 
 - This repository is a Rust CLI project.
 - The primary binary is `airis`.
-- `manifest.toml` drives workspace discovery, generation, orchestration, guards, and related automation.
+- `manifest.toml` is the thin source of truth that drives convention generation (AI adapters, docs, `tsconfig.json`, scaffolding) and, for containerized repos, Docker environment generation.
 
 ## Common Commands
 

--- a/.claude/rules/generated/WORKFLOW.md
+++ b/.claude/rules/generated/WORKFLOW.md
@@ -11,8 +11,8 @@
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
-- **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
-- **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+- **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
+- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
 
 ## Operational Notes
 

--- a/.cursor/rules/PROJECT_RULES.md
+++ b/.cursor/rules/PROJECT_RULES.md
@@ -2,7 +2,7 @@
 
 ## Architectural Boundaries
 
-Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygiene Enforcer**. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Its primary value is ensuring a host-hygienic Docker development environment through automated orchestration.
+Airis-workspace is a **polyglot monorepo convention-unification engine**. From a thin `manifest.toml` it keeps a heterogeneous set of repositories consistent: AI adapter files, shared docs, `tsconfig.json`, version scheme, and project scaffolding. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Docker development-environment generation (`compose.yaml`, volume hygiene) is **one module**, serving the subset of repositories that are containerized — not the whole tool.
 
 ## Design Principles
 
@@ -21,7 +21,7 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Non-Negotiables
 
 - For **runtime application** configuration (DB-backed settings, tenant boundaries, feature flags), follow `docs/ai/architecture-invariants.md` alongside this file—`manifest.toml` remains the SoT for workspace tooling, not for per-app DB config.
-- Preserve the Docker-first value proposition of airis. Changes must not weaken command guards or make host-side workflows the default path.
+- For containerized repositories, preserve the integrity of the Docker module (safe `compose.yaml` merge that never destroys user-authored services, volume hygiene). Do not weaken it — but do not impose Docker-first defaults on repositories that don't use it (e.g. Edge/Workers, native desktop apps).
 - Keep `airis gen` and the `workspace_init`/`manifest_apply` MCP tools safe by default. Avoid destructive overwrites unless the feature explicitly supports backups or opt-in replacement.
 - Prefer minimal, reviewable diffs. When changing generation or enforcement logic, document the intended invariant.
 

--- a/.cursor/rules/REVIEW.md
+++ b/.cursor/rules/REVIEW.md
@@ -2,8 +2,8 @@
 
 ## Primary Checks
 
-- Does the change preserve or strengthen Docker-first enforcement?
-- Does it keep `manifest.toml` authoritative for workspace and guard behavior?
+- Does the change keep the convention-unification engine coherent — AI adapters, docs, `tsconfig.json`, and scaffolding consistent across repos?
+- Does it keep `manifest.toml` authoritative as the thin source of truth, and the Docker module safe for containerized repos?
 - Are generated files or adapters clearly marked and reproducible?
 - Are vendor-specific differences isolated instead of duplicated into shared docs?
 

--- a/.cursor/rules/STACK.md
+++ b/.cursor/rules/STACK.md
@@ -4,7 +4,7 @@
 
 - This repository is a Rust CLI project.
 - The primary binary is `airis`.
-- `manifest.toml` drives workspace discovery, generation, orchestration, guards, and related automation.
+- `manifest.toml` is the thin source of truth that drives convention generation (AI adapters, docs, `tsconfig.json`, scaffolding) and, for containerized repos, Docker environment generation.
 
 ## Common Commands
 

--- a/.cursor/rules/WORKFLOW.md
+++ b/.cursor/rules/WORKFLOW.md
@@ -11,8 +11,8 @@
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
-- **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
-- **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+- **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
+- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
 
 ## Operational Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Primary project instructions. Read these first.
 
 ## Architectural Boundaries
 
-Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygiene Enforcer**. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Its primary value is ensuring a host-hygienic Docker development environment through automated orchestration.
+Airis-workspace is a **polyglot monorepo convention-unification engine**. From a thin `manifest.toml` it keeps a heterogeneous set of repositories consistent: AI adapter files, shared docs, `tsconfig.json`, version scheme, and project scaffolding. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Docker development-environment generation (`compose.yaml`, volume hygiene) is **one module**, serving the subset of repositories that are containerized — not the whole tool.
 
 ## Design Principles
 
@@ -27,7 +27,7 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Non-Negotiables
 
 - For **runtime application** configuration (DB-backed settings, tenant boundaries, feature flags), follow `docs/ai/architecture-invariants.md` alongside this file—`manifest.toml` remains the SoT for workspace tooling, not for per-app DB config.
-- Preserve the Docker-first value proposition of airis. Changes must not weaken command guards or make host-side workflows the default path.
+- For containerized repositories, preserve the integrity of the Docker module (safe `compose.yaml` merge that never destroys user-authored services, volume hygiene). Do not weaken it — but do not impose Docker-first defaults on repositories that don't use it (e.g. Edge/Workers, native desktop apps).
 - Keep `airis gen` and the `workspace_init`/`manifest_apply` MCP tools safe by default. Avoid destructive overwrites unless the feature explicitly supports backups or opt-in replacement.
 - Prefer minimal, reviewable diffs. When changing generation or enforcement logic, document the intended invariant.
 
@@ -53,8 +53,8 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
-- **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
-- **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+- **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
+- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
 
 ## Operational Notes
 
@@ -74,8 +74,8 @@ These are easy to discover the hard way. Read once, save a debugging session.
 
 ## Primary Checks
 
-- Does the change preserve or strengthen Docker-first enforcement?
-- Does it keep `manifest.toml` authoritative for workspace and guard behavior?
+- Does the change keep the convention-unification engine coherent — AI adapters, docs, `tsconfig.json`, and scaffolding consistent across repos?
+- Does it keep `manifest.toml` authoritative as the thin source of truth, and the Docker module safe for containerized repos?
 - Are generated files or adapters clearly marked and reproducible?
 - Are vendor-specific differences isolated instead of duplicated into shared docs?
 
@@ -94,7 +94,7 @@ These are easy to discover the hard way. Read once, save a debugging session.
 
 - This repository is a Rust CLI project.
 - The primary binary is `airis`.
-- `manifest.toml` drives workspace discovery, generation, orchestration, guards, and related automation.
+- `manifest.toml` is the thin source of truth that drives convention generation (AI adapters, docs, `tsconfig.json`, scaffolding) and, for containerized repos, Docker environment generation.
 
 ## Common Commands
 
@@ -162,7 +162,7 @@ Primary project instructions live in shared documentation:
 
 Always:
 - Read the shared instructions before major edits.
-- Treat `manifest.toml` as the machine-readable source of truth for Docker-first workflow, commands, and guards.
+- Treat `manifest.toml` as the machine-readable source of truth for convention generation (AI adapters, docs, tsconfig, scaffolding) and, for containerized repos, Docker environment generation.
 - Prefer minimal diffs and run the smallest relevant verification before finishing.
 - Reuse task-specific playbooks from `docs/ai/playbooks` when the task matches.
 - When working with hooks or guard automation, follow `docs/ai/hooks/HOOKS_POLICY.md` as the portable policy source.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Primary project instructions. Read these first.
 
 ## Architectural Boundaries
 
-Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygiene Enforcer**. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Its primary value is ensuring a host-hygienic Docker development environment through automated orchestration.
+Airis-workspace is a **polyglot monorepo convention-unification engine**. From a thin `manifest.toml` it keeps a heterogeneous set of repositories consistent: AI adapter files, shared docs, `tsconfig.json`, version scheme, and project scaffolding. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Docker development-environment generation (`compose.yaml`, volume hygiene) is **one module**, serving the subset of repositories that are containerized — not the whole tool.
 
 ## Design Principles
 
@@ -27,7 +27,7 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Non-Negotiables
 
 - For **runtime application** configuration (DB-backed settings, tenant boundaries, feature flags), follow `docs/ai/architecture-invariants.md` alongside this file—`manifest.toml` remains the SoT for workspace tooling, not for per-app DB config.
-- Preserve the Docker-first value proposition of airis. Changes must not weaken command guards or make host-side workflows the default path.
+- For containerized repositories, preserve the integrity of the Docker module (safe `compose.yaml` merge that never destroys user-authored services, volume hygiene). Do not weaken it — but do not impose Docker-first defaults on repositories that don't use it (e.g. Edge/Workers, native desktop apps).
 - Keep `airis gen` and the `workspace_init`/`manifest_apply` MCP tools safe by default. Avoid destructive overwrites unless the feature explicitly supports backups or opt-in replacement.
 - Prefer minimal, reviewable diffs. When changing generation or enforcement logic, document the intended invariant.
 
@@ -53,8 +53,8 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
-- **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
-- **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+- **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
+- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
 
 ## Operational Notes
 
@@ -74,8 +74,8 @@ These are easy to discover the hard way. Read once, save a debugging session.
 
 ## Primary Checks
 
-- Does the change preserve or strengthen Docker-first enforcement?
-- Does it keep `manifest.toml` authoritative for workspace and guard behavior?
+- Does the change keep the convention-unification engine coherent — AI adapters, docs, `tsconfig.json`, and scaffolding consistent across repos?
+- Does it keep `manifest.toml` authoritative as the thin source of truth, and the Docker module safe for containerized repos?
 - Are generated files or adapters clearly marked and reproducible?
 - Are vendor-specific differences isolated instead of duplicated into shared docs?
 
@@ -94,7 +94,7 @@ These are easy to discover the hard way. Read once, save a debugging session.
 
 - This repository is a Rust CLI project.
 - The primary binary is `airis`.
-- `manifest.toml` drives workspace discovery, generation, orchestration, guards, and related automation.
+- `manifest.toml` is the thin source of truth that drives convention generation (AI adapters, docs, `tsconfig.json`, scaffolding) and, for containerized repos, Docker environment generation.
 
 ## Common Commands
 
@@ -161,7 +161,7 @@ Read these files first:
 - `docs/ai/STACK.md`
 
 Repository rules:
-- `manifest.toml` remains the source of truth for Docker-first orchestration, command guards, and generated workspace config.
+- `manifest.toml` is the thin source of truth for convention generation (AI adapters, docs, tsconfig, scaffolding) and, for containerized repos, Docker environment generation.
 - Follow the shared docs for architecture, workflow, and review expectations.
 - Keep verification proportional to the change.
 - Project playbooks and reusable task guidance live under `docs/ai/playbooks`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ Primary project instructions. Read these first.
 
 ## Architectural Boundaries
 
-Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygiene Enforcer**. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Its primary value is ensuring a host-hygienic Docker development environment through automated orchestration.
+Airis-workspace is a **polyglot monorepo convention-unification engine**. From a thin `manifest.toml` it keeps a heterogeneous set of repositories consistent: AI adapter files, shared docs, `tsconfig.json`, version scheme, and project scaffolding. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Docker development-environment generation (`compose.yaml`, volume hygiene) is **one module**, serving the subset of repositories that are containerized — not the whole tool.
 
 ## Design Principles
 
@@ -27,7 +27,7 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Non-Negotiables
 
 - For **runtime application** configuration (DB-backed settings, tenant boundaries, feature flags), follow `docs/ai/architecture-invariants.md` alongside this file—`manifest.toml` remains the SoT for workspace tooling, not for per-app DB config.
-- Preserve the Docker-first value proposition of airis. Changes must not weaken command guards or make host-side workflows the default path.
+- For containerized repositories, preserve the integrity of the Docker module (safe `compose.yaml` merge that never destroys user-authored services, volume hygiene). Do not weaken it — but do not impose Docker-first defaults on repositories that don't use it (e.g. Edge/Workers, native desktop apps).
 - Keep `airis gen` and the `workspace_init`/`manifest_apply` MCP tools safe by default. Avoid destructive overwrites unless the feature explicitly supports backups or opt-in replacement.
 - Prefer minimal, reviewable diffs. When changing generation or enforcement logic, document the intended invariant.
 
@@ -53,8 +53,8 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
-- **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
-- **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+- **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
+- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
 
 ## Operational Notes
 
@@ -74,8 +74,8 @@ These are easy to discover the hard way. Read once, save a debugging session.
 
 ## Primary Checks
 
-- Does the change preserve or strengthen Docker-first enforcement?
-- Does it keep `manifest.toml` authoritative for workspace and guard behavior?
+- Does the change keep the convention-unification engine coherent — AI adapters, docs, `tsconfig.json`, and scaffolding consistent across repos?
+- Does it keep `manifest.toml` authoritative as the thin source of truth, and the Docker module safe for containerized repos?
 - Are generated files or adapters clearly marked and reproducible?
 - Are vendor-specific differences isolated instead of duplicated into shared docs?
 
@@ -94,7 +94,7 @@ These are easy to discover the hard way. Read once, save a debugging session.
 
 - This repository is a Rust CLI project.
 - The primary binary is `airis`.
-- `manifest.toml` drives workspace discovery, generation, orchestration, guards, and related automation.
+- `manifest.toml` is the thin source of truth that drives convention generation (AI adapters, docs, `tsconfig.json`, scaffolding) and, for containerized repos, Docker environment generation.
 
 ## Common Commands
 
@@ -169,4 +169,4 @@ Hook policy:
 Testing policy:
 - **Mock policy: forbidden** — Never mock external services (DB, APIs). Use real instances or local emulators.
 
-`manifest.toml` remains the machine-readable source of truth for Docker-first workflow, commands, and guards.
+`manifest.toml` is the machine-readable source of truth for convention generation (AI adapters, docs, tsconfig, scaffolding) and, for containerized repos, Docker environment generation.

--- a/docs/ai/PROJECT_RULES.md
+++ b/docs/ai/PROJECT_RULES.md
@@ -2,7 +2,7 @@
 
 ## Architectural Boundaries
 
-Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygiene Enforcer**. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Its primary value is ensuring a host-hygienic Docker development environment through automated orchestration.
+Airis-workspace is a **polyglot monorepo convention-unification engine**. From a thin `manifest.toml` it keeps a heterogeneous set of repositories consistent: AI adapter files, shared docs, `tsconfig.json`, version scheme, and project scaffolding. It is not a build orchestrator (like Nx/Turborepo) or a package manager replacement. Docker development-environment generation (`compose.yaml`, volume hygiene) is **one module**, serving the subset of repositories that are containerized — not the whole tool.
 
 ## Design Principles
 
@@ -21,7 +21,7 @@ Airis-workspace is an **Environment Source-of-Truth, Config Compiler, and Hygien
 ## Non-Negotiables
 
 - For **runtime application** configuration (DB-backed settings, tenant boundaries, feature flags), follow `docs/ai/architecture-invariants.md` alongside this file—`manifest.toml` remains the SoT for workspace tooling, not for per-app DB config.
-- Preserve the Docker-first value proposition of airis. Changes must not weaken command guards or make host-side workflows the default path.
+- For containerized repositories, preserve the integrity of the Docker module (safe `compose.yaml` merge that never destroys user-authored services, volume hygiene). Do not weaken it — but do not impose Docker-first defaults on repositories that don't use it (e.g. Edge/Workers, native desktop apps).
 - Keep `airis gen` and the `workspace_init`/`manifest_apply` MCP tools safe by default. Avoid destructive overwrites unless the feature explicitly supports backups or opt-in replacement.
 - Prefer minimal, reviewable diffs. When changing generation or enforcement logic, document the intended invariant.
 

--- a/docs/ai/REVIEW.md
+++ b/docs/ai/REVIEW.md
@@ -2,8 +2,8 @@
 
 ## Primary Checks
 
-- Does the change preserve or strengthen Docker-first enforcement?
-- Does it keep `manifest.toml` authoritative for workspace and guard behavior?
+- Does the change keep the convention-unification engine coherent — AI adapters, docs, `tsconfig.json`, and scaffolding consistent across repos?
+- Does it keep `manifest.toml` authoritative as the thin source of truth, and the Docker module safe for containerized repos?
 - Are generated files or adapters clearly marked and reproducible?
 - Are vendor-specific differences isolated instead of duplicated into shared docs?
 

--- a/docs/ai/STACK.md
+++ b/docs/ai/STACK.md
@@ -4,7 +4,7 @@
 
 - This repository is a Rust CLI project.
 - The primary binary is `airis`.
-- `manifest.toml` drives workspace discovery, generation, orchestration, guards, and related automation.
+- `manifest.toml` is the thin source of truth that drives convention generation (AI adapters, docs, `tsconfig.json`, scaffolding) and, for containerized repos, Docker environment generation.
 
 ## Common Commands
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -11,8 +11,8 @@
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
-- **Environment Focus**: Treat Airis as an environment orchestrator, not a task runner or package manager.
-- **Hygiene**: Never introduce host-side dependencies. Keep AI agents inside the container.
+- **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
+- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
 
 ## Operational Notes
 

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -321,7 +321,7 @@ fn render_agents_md(
     lines.push("".to_string());
     lines.push("Always:".to_string());
     lines.push("- Read the shared instructions before major edits.".to_string());
-    lines.push("- Treat `manifest.toml` as the machine-readable source of truth for Docker-first workflow, commands, and guards.".to_string());
+    lines.push("- Treat `manifest.toml` as the machine-readable source of truth for convention generation (AI adapters, docs, tsconfig, scaffolding) and, for containerized repos, Docker environment generation.".to_string());
     lines.push(
         "- Prefer minimal diffs and run the smallest relevant verification before finishing."
             .to_string(),
@@ -372,7 +372,7 @@ fn render_claude_md(
     lines.extend(sources.iter().map(|source| format!("- `{}`", source)));
     lines.push("".to_string());
     lines.push("Repository rules:".to_string());
-    lines.push("- `manifest.toml` remains the source of truth for Docker-first orchestration, command guards, and generated workspace config.".to_string());
+    lines.push("- `manifest.toml` is the thin source of truth for convention generation (AI adapters, docs, tsconfig, scaffolding) and, for containerized repos, Docker environment generation.".to_string());
     lines.push(
         "- Follow the shared docs for architecture, workflow, and review expectations.".to_string(),
     );
@@ -439,7 +439,7 @@ fn render_gemini_md(
 
     lines.push("".to_string());
     lines.push(
-        "`manifest.toml` remains the machine-readable source of truth for Docker-first workflow, commands, and guards.".to_string(),
+        "`manifest.toml` is the machine-readable source of truth for convention generation (AI adapters, docs, tsconfig, scaffolding) and, for containerized repos, Docker environment generation.".to_string(),
     );
     lines.join("\n")
 }
@@ -474,7 +474,7 @@ fn render_cursorrules(
 
     lines.push("".to_string());
     lines.push(
-        "`manifest.toml` stays authoritative for Docker-first workflow and guard configuration."
+        "`manifest.toml` stays authoritative for convention generation and, for containerized repos, Docker environment configuration."
             .to_string(),
     );
     lines.join("\n")

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -928,7 +928,7 @@ fn handle_workspace_status() -> Result<Value> {
 const WORKSPACE_RESOURCES: &[(&str, &str, &str)] = &[
     (
         "manifest.toml",
-        "Workspace manifest — Docker-first orchestration source of truth",
+        "Workspace manifest — thin source of truth for convention generation",
         "application/toml",
     ),
     (


### PR DESCRIPTION
## What

Redefine airis's stated identity from **"Docker-first environment compiler that enforces host hygiene everywhere"** to **"polyglot monorepo convention-unification engine"**. Docker compose/volume generation is reframed as *one module* serving containerized repos — not the whole tool.

## Why

A read-only audit across the org showed the original essence has eroded:

- **The Docker-first-everywhere premise broke.** The org diversified into Edge/Workers (host pnpm is canonical) and native desktop apps (Docker irrelevant). The `guards` subsystem was already removed because Docker-first enforcement *blocked* that work.
- **The Turborepo reinvention is unused.** `affected` / `remote_cache` / `bundle` / `test_scan` have zero external consumers; agiletec's CI uses real `pnpm turbo run --affected`.
- **The actual org-wide value is convention consistency.** `airis gen` (the dominant command in CI) keeps heterogeneous repos aligned: AI adapters, docs, tsconfig, version scheme, scaffolding. The essence statement now reflects that.

This is the first of a phased refocus. Later phases remove the dead Turborepo-reinvention commands.

## Changes

- `docs/ai/{PROJECT_RULES,STACK,REVIEW,WORKFLOW}.md` — reword the essence; scope Docker hygiene to containerized repos only.
- `src/commands/docs.rs` (4 strings) + `src/commands/mcp/mod.rs` (1 string) — fix generator output that hardcoded the old essence and referenced the **already-removed** `command guards`.
- Regenerated `CLAUDE/AGENTS/GEMINI.md` + `.claude/rules/generated/*` + `.cursor/rules/*` via `airis gen`.

## Verification

`cargo build` / `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` (360 unit + 20 integration + doctests) all pass. No stale old-essence strings remain in tracked files.

## Noted (not fixed here)

`CLAUDE/AGENTS/GEMINI.md` are written by **two** commands (`airis gen` writes the `BEGIN/END` block; `airis docs sync` writes the tail), which fight over the same files. Pre-existing design debt, out of scope for this PR — flagged for a follow-up to consolidate onto one generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)