### PR TITLE
ci: fix auto-merge — wait for CI then direct-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,66 +1,88 @@
 name: Auto-merge
+
+# Why this is not GitHub's native auto-merge:
+#
+# `enablePullRequestAutoMerge` / `gh pr merge --auto` only work when the base
+# branch has a protection rule with at least one *required* status check or
+# review (the PR must have a pending requirement to wait on). This repo's
+# ruleset intentionally requires only a PR + non-fast-forward — no required
+# checks (CI runs for visibility, not as a merge gate). With no required
+# requirement, the native mutation is rejected as "unstable" (checks running)
+# or "clean status" (nothing to wait for), so it can never succeed here.
+#   docs.github.com/.../managing-auto-merge-for-pull-requests-in-your-repository
+#   github.com/orgs/community/discussions/190610  (2026-03 behavior change)
+#
+# Instead we wait for the CI workflow to finish via `workflow_run` and merge
+# directly when it concluded green. `workflow_run` runs on the default branch
+# *after* CI, so this job is not itself part of the PR's check suite — it can
+# evaluate the result without the self-reference loop that made the old
+# `pull_request`-triggered job fail and pin the PR in an unstable state.
+#
+# Note: merging with GITHUB_TOKEN does not trigger downstream workflow runs.
+# That is fine here — releases are tag-driven, not main-push-driven.
+
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
 
 jobs:
-  enable-auto-merge:
+  merge-on-green:
+    # Only for pull-request CI runs that concluded successfully.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge (merge commit)
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            const nodeId = pr.data.node_id;
-            const mutation = `
-              mutation EnableAutoMerge($id: ID!) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $id,
-                  mergeMethod: MERGE
-                }) {
-                  pullRequest { number autoMergeRequest { mergeMethod } }
-                }
-              }
-            `;
-            // Retry with exponential backoff.
-            // GitHub rejects with UNPROCESSABLE in two cases:
-            //   1. PR was just opened and checks haven't started yet ("unstable")
-            //   2. All required checks already passed before this mutation ran
-            //      (breaking change introduced ~March 2026)
-            // In case 2 GitHub will auto-merge without this mutation, so we
-            // treat both as non-fatal and retry until the window opens or give up.
-            const maxAttempts = 6;
-            for (let i = 0; i < maxAttempts; i++) {
-              try {
-                await github.graphql(mutation, { id: nodeId });
-                console.log('Auto-merge enabled.');
-                break;
-              } catch (e) {
-                const msg = e.message ?? '';
-                const isUnstable = msg.includes('unstable') ||
-                  (e.errors ?? []).some(err => (err.message ?? '').includes('unstable'));
-                const alreadyEnabled = msg.includes('already enabled') ||
-                  (e.errors ?? []).some(err => (err.message ?? '').includes('already enabled'));
-                if (alreadyEnabled) {
-                  console.log('Auto-merge already enabled, skipping.');
-                  break;
-                }
-                if (isUnstable && i < maxAttempts - 1) {
-                  const delay = Math.min(5000 * 2 ** i, 30000);
-                  console.log(`PR unstable (attempt ${i + 1}/${maxAttempts}), retrying in ${delay}ms…`);
-                  await new Promise(r => setTimeout(r, delay));
-                } else {
-                  throw e;
-                }
-              }
-            }
+      - name: Merge the PR for this branch when it is mergeable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+
+          # Find the open PR whose head branch + commit produced this CI run.
+          pr_number=$(gh pr list --repo "$REPO" --head "$HEAD_BRANCH" --state open \
+            --json number,headRefOid \
+            --jq "map(select(.headRefOid == \"$HEAD_SHA\")) | .[0].number // empty")
+
+          if [ -z "$pr_number" ]; then
+            echo "No open PR for $HEAD_BRANCH @ $HEAD_SHA (stale or already merged) — nothing to do."
+            exit 0
+          fi
+
+          # Re-read mergeability; GitHub computes it asynchronously, so retry
+          # a few times while it is UNKNOWN before giving up.
+          for attempt in 1 2 3 4 5; do
+            read -r is_draft mergeable state < <(gh pr view "$pr_number" --repo "$REPO" \
+              --json isDraft,mergeable,state \
+              --jq '[.isDraft, .mergeable, .state] | @tsv')
+
+            if [ "$state" != "OPEN" ]; then
+              echo "PR #$pr_number is $state — nothing to do."
+              exit 0
+            fi
+            if [ "$is_draft" = "true" ]; then
+              echo "PR #$pr_number is a draft — skipping."
+              exit 0
+            fi
+            if [ "$mergeable" = "CONFLICTING" ]; then
+              echo "::warning::PR #$pr_number has conflicts — leaving it for manual resolution."
+              exit 0
+            fi
+            if [ "$mergeable" = "MERGEABLE" ]; then
+              echo "Merging PR #$pr_number (CI green on $HEAD_SHA)…"
+              gh pr merge "$pr_number" --repo "$REPO" --merge --delete-branch
+              exit 0
+            fi
+            echo "Mergeability UNKNOWN (attempt $attempt/5), waiting…"
+            sleep 5
+          done
+
+          echo "::warning::PR #$pr_number mergeability stayed UNKNOWN — leaving for manual merge."


### PR DESCRIPTION
## Problem

The `enable-auto-merge` job has been **failing on every PR**, which pins each PR in an `UNSTABLE` state so nothing merges (real checks pass, but the failed auto-merge job keeps the PR from going `clean`).

### Root cause (confirmed against official docs)

GitHub's native auto-merge (`enablePullRequestAutoMerge` / `gh pr merge --auto`) **requires a branch protection rule with at least one _required_ status check or review** — the PR needs a pending requirement to wait on. This repo's ruleset is `["pull_request", "non_fast_forward"]` with **no required status checks** (CI runs for visibility, not as a merge gate). With no required requirement, the mutation is rejected as:

- `"unstable status"` while checks are running, or
- `"clean status"` once they finish (nothing to wait on).

The old job retried for ~95s (shorter than CI), then `throw`'d. Because it was a `pull_request`-triggered check, **its own failure** is what kept every PR `UNSTABLE`.

Sources:
- [Managing auto-merge — GitHub Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository) (requires a branch-protection requirement)
- [peter-evans/enable-pull-request-automerge](https://github.com/peter-evans/enable-pull-request-automerge) (same prerequisite; merges directly if already mergeable)
- [community #190610](https://github.com/orgs/community/discussions/190610) (2026-03 behavior change, HTTP 422)

## Fix

Use the correct pattern for a **no-required-checks** repo: trigger on `workflow_run` after **CI** completes and **merge directly** when CI concluded green and the PR is mergeable.

- Running on `workflow_run` (default branch, after CI) keeps this job **out of the PR's own check suite**, breaking the self-reference loop that caused the stuck state.
- Draft / conflicting / `UNKNOWN`-mergeability PRs are left for manual handling (`::warning::`) instead of failing loudly.
- Note: GITHUB_TOKEN merges don't trigger downstream workflows — fine here, releases are tag-driven.

## ⚠️ Rollout (chicken-and-egg)

`workflow_run` workflows only take effect from the **default branch**, so:
1. **This PR must be merged manually** (the old broken job still governs it).
2. The in-flight PRs **#272 / #273** also need a manual merge (or a fresh CI run) — their CI already completed before this workflow exists on main, so it won't fire for them retroactively.
3. Every PR opened **after** this merges will auto-merge on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)