### PR TITLE
docs: frame Docker as one module, not airis's whole identity

### DIFF
--- a/.claude/rules/generated/STACK.md
+++ b/.claude/rules/generated/STACK.md
@@ -49,10 +49,17 @@ airis hooks uninstall      # removes the airis-workspace blocks (keeps other hoo
 
 The `post-commit` hook (which reinstalls the `airis` binary in the background) is installed separately by `airis hooks install`.
 
+## Module Boundary
+
+airis is a convention-unification engine; Docker is one module within it, not the whole tool.
+
+- **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
+- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+
 ## Important Paths
 
 - `src/manifest/` for manifest schema and validation
 - `src/commands/` for CLI behavior
-- `src/commands/hooks.rs` + `src/commands/generate/hooks_gen.rs` for git hook install/generation
+- `src/commands/generate/compose_gen.rs` for the Docker module's `compose.yaml` generation
 - `docs/ai/` for shared AI guidance (source of truth for adapter files)
 - `tests/cli_test.rs` for end-to-end CLI integration tests

--- a/.cursor/rules/STACK.md
+++ b/.cursor/rules/STACK.md
@@ -49,10 +49,17 @@ airis hooks uninstall      # removes the airis-workspace blocks (keeps other hoo
 
 The `post-commit` hook (which reinstalls the `airis` binary in the background) is installed separately by `airis hooks install`.
 
+## Module Boundary
+
+airis is a convention-unification engine; Docker is one module within it, not the whole tool.
+
+- **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
+- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+
 ## Important Paths
 
 - `src/manifest/` for manifest schema and validation
 - `src/commands/` for CLI behavior
-- `src/commands/hooks.rs` + `src/commands/generate/hooks_gen.rs` for git hook install/generation
+- `src/commands/generate/compose_gen.rs` for the Docker module's `compose.yaml` generation
 - `docs/ai/` for shared AI guidance (source of truth for adapter files)
 - `tests/cli_test.rs` for end-to-end CLI integration tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,11 +139,18 @@ airis hooks uninstall      # removes the airis-workspace blocks (keeps other hoo
 
 The `post-commit` hook (which reinstalls the `airis` binary in the background) is installed separately by `airis hooks install`.
 
+## Module Boundary
+
+airis is a convention-unification engine; Docker is one module within it, not the whole tool.
+
+- **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
+- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+
 ## Important Paths
 
 - `src/manifest/` for manifest schema and validation
 - `src/commands/` for CLI behavior
-- `src/commands/hooks.rs` + `src/commands/generate/hooks_gen.rs` for git hook install/generation
+- `src/commands/generate/compose_gen.rs` for the Docker module's `compose.yaml` generation
 - `docs/ai/` for shared AI guidance (source of truth for adapter files)
 - `tests/cli_test.rs` for end-to-end CLI integration tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,11 +139,18 @@ airis hooks uninstall      # removes the airis-workspace blocks (keeps other hoo
 
 The `post-commit` hook (which reinstalls the `airis` binary in the background) is installed separately by `airis hooks install`.
 
+## Module Boundary
+
+airis is a convention-unification engine; Docker is one module within it, not the whole tool.
+
+- **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
+- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+
 ## Important Paths
 
 - `src/manifest/` for manifest schema and validation
 - `src/commands/` for CLI behavior
-- `src/commands/hooks.rs` + `src/commands/generate/hooks_gen.rs` for git hook install/generation
+- `src/commands/generate/compose_gen.rs` for the Docker module's `compose.yaml` generation
 - `docs/ai/` for shared AI guidance (source of truth for adapter files)
 - `tests/cli_test.rs` for end-to-end CLI integration tests
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -139,11 +139,18 @@ airis hooks uninstall      # removes the airis-workspace blocks (keeps other hoo
 
 The `post-commit` hook (which reinstalls the `airis` binary in the background) is installed separately by `airis hooks install`.
 
+## Module Boundary
+
+airis is a convention-unification engine; Docker is one module within it, not the whole tool.
+
+- **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
+- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+
 ## Important Paths
 
 - `src/manifest/` for manifest schema and validation
 - `src/commands/` for CLI behavior
-- `src/commands/hooks.rs` + `src/commands/generate/hooks_gen.rs` for git hook install/generation
+- `src/commands/generate/compose_gen.rs` for the Docker module's `compose.yaml` generation
 - `docs/ai/` for shared AI guidance (source of truth for adapter files)
 - `tests/cli_test.rs` for end-to-end CLI integration tests
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A few minutes later, your Mac has:
 
 AIRIS Workspace exists to stop that.
 
-It is a **Rust-powered Docker-first workspace guard** for the AI coding era.  
+It is a **Rust-powered workspace engine** for the AI coding era — Docker-first host hygiene for containerized repos, plus consistent conventions (AI rules, docs, tsconfig, scaffolding) across the monorepo.  
 Humans and AI agents can keep typing normal commands:
 
 ```bash

--- a/docs/ai/STACK.md
+++ b/docs/ai/STACK.md
@@ -49,10 +49,17 @@ airis hooks uninstall      # removes the airis-workspace blocks (keeps other hoo
 
 The `post-commit` hook (which reinstalls the `airis` binary in the background) is installed separately by `airis hooks install`.
 
+## Module Boundary
+
+airis is a convention-unification engine; Docker is one module within it, not the whole tool.
+
+- **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
+- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+
 ## Important Paths
 
 - `src/manifest/` for manifest schema and validation
 - `src/commands/` for CLI behavior
-- `src/commands/hooks.rs` + `src/commands/generate/hooks_gen.rs` for git hook install/generation
+- `src/commands/generate/compose_gen.rs` for the Docker module's `compose.yaml` generation
 - `docs/ai/` for shared AI guidance (source of truth for adapter files)
 - `tests/cli_test.rs` for end-to-end CLI integration tests

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "airis")]
-#[command(about = "The Docker-first environment orchestrator for the vibe coding era")]
+#[command(about = "Convention engine for polyglot monorepos (Docker dev-env is one module)")]
 #[command(long_about = "\
 A workspace orchestrator for monorepos.
 


### PR DESCRIPTION
## What

Phase 2 (final) of the essence refocus. Phase 0 (#272) reworded the shared docs; Phase 1 (#273) removed the off-essence build cluster. This makes the **"Docker is one module"** framing concrete in the remaining identity strings and documents the module boundary. **No logic changes.**

- **`src/cli.rs`** — the `about` tagline was still *"The Docker-first environment orchestrator for the vibe coding era"*. Now *"Convention engine for polyglot monorepos (Docker dev-env is one module)"*.
- **`README.md`** — the lead tagline called airis a *"Docker-first workspace **guard**"* (guards were removed, and it over-claimed Docker-first as the whole identity). Now a *"workspace engine"* — Docker host hygiene for containerized repos **plus** cross-repo convention consistency. The hygiene narrative (its real value for containerized repos) is kept.
- **`docs/ai/STACK.md`** — adds a **Module boundary** section splitting the command surface into *Convention core* (every repo) vs *Docker module* (containerized repos only), and notes `[docker]` is optional (`#[serde(default)]`) so non-containerized repos (Edge/Workers, native desktop) use airis without it. Also fixes a stale Important-Paths entry pointing at the removed `hooks.rs` files.

## Verification

- `cargo build` / `fmt --check` / `clippy -- -D warnings` / `cargo test` (329 unit + 5 integration) pass.
- Compose/volume generation is untouched, so **`airis gen` output for consumer repos is unchanged**. Adapters regenerated via `airis gen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)