### PR TITLE
ci: adopt org Rust baseline reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,101 +1,22 @@
 name: CI
 
+# Org reusable CI caller — opinionated Rust baseline (fmt + clippy + test + audit),
+# plus the crate-specific gates this published crate needs.
+# Logic lives in agiletec-inc/.github. Required checks: "secret-scan / scan", "ci / ci".
+# (Real release builds live in release.yml / publish-crates.yml.)
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
+  merge_group:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: clippy, rustfmt
-          rustflags: ""
-
-      - name: Check formatting
-        run: cargo fmt --check
-
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-
-      - name: Run tests
-        run: cargo test
-
-      - name: Build release
-        run: cargo build --release
-
-      - name: Package (debug sizing — replicates crates.io upload environment)
-        run: |
-          set -euo pipefail
-          echo "=== cargo package --list (full file inventory) ==="
-          cargo package --list --allow-dirty
-          echo ""
-          echo "=== Running cargo package --no-verify ==="
-          cargo package --no-verify --allow-dirty
-          echo ""
-          echo "=== Generated .crate size ==="
-          ls -lh target/package/*.crate
-          echo ""
-          echo "=== Uncompressed package dir size (top-level breakdown) ==="
-          CRATE_DIR=$(find target/package -maxdepth 1 -type d -name 'airis-workspace-*' | head -1)
-          if [ -n "$CRATE_DIR" ]; then
-            du -sh "$CRATE_DIR"
-            echo ""
-            echo "=== Top 20 largest files inside package ==="
-            find "$CRATE_DIR" -type f -printf '%s %p\n' | sort -rn | head -20
-            echo ""
-            echo "=== Size by top-level subdirectory ==="
-            du -sh "$CRATE_DIR"/* 2>/dev/null | sort -rh
-          fi
-          echo ""
-          echo "=== 10MB limit check ==="
-          CRATE_FILE=$(ls target/package/*.crate | head -1)
-          CRATE_BYTES=$(stat -c%s "$CRATE_FILE")
-          LIMIT=10485760
-          echo "Crate size: $CRATE_BYTES bytes"
-          echo "Limit:      $LIMIT bytes"
-          if [ "$CRATE_BYTES" -gt "$LIMIT" ]; then
-            echo "::error::Package exceeds crates.io 10MB limit ($CRATE_BYTES > $LIMIT)"
-            exit 1
-          fi
-          echo "OK: under limit"
-
-  windows-check:
-    # Catches Windows-only compilation breakage (e.g. unguarded `std::os::unix`
-    # APIs) before it reaches the cargo-dist release pipeline. Runs natively on
-    # a Windows runner — free for public repos and avoids the Windows SDK
-    # headers that a Linux cross-compile of native deps (ring) would require.
-    runs-on: windows-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          rustflags: ""
-
-      - name: Cargo check
-        run: cargo check --all-targets
-
-  dependency-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run cargo audit
-        uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+  secret-scan:
+    uses: agiletec-inc/.github/.github/workflows/secret-scan.yml@main
+  ci:
+    uses: agiletec-inc/.github/.github/workflows/rust-cargo-ci.yml@main
+    with:
+      package-size-check: true   # crates.io 10MB limit
+      windows-check: true        # catch Windows-only breakage


### PR DESCRIPTION
Replace bespoke ci.yml with the org `rust-cargo-ci` baseline (fmt + clippy + test + audit), enabling `package-size-check` (crates.io 10MB) and `windows-check` to preserve this crate's specific gates. Real release builds remain in release.yml / publish-crates.yml. Baseline clippy/test run `--all-targets --all-features` (stricter than before) — may surface pre-existing issues to fix. Required checks: `secret-scan / scan`, `ci / ci`.