### PR TITLE
chore: remove dead guard/shim remnants from May refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `manifest_validate`, `manifest_apply`, `migration_execute`).
 ### Removed
 
+- Dead guard/shim remnants left behind by the May removal (472ec2e): the MCP
+  server no longer advertises the broken `guards_install` / `guards_status` /
+  `guards_uninstall` tools (they subprocess-called the deleted `airis guards`
+  subcommand and failed at runtime), the unused `shim_commands` manifest field
+  is gone (old manifests containing it still parse — unknown keys are ignored),
+  `airis new` no longer emits a `[guards]` section, and stale
+  `AIRIS_SKIP_GUARD` / `AIRIS_BYPASS` checks and shim docstrings were removed.
 - `src/commands/init.rs` and `Commands::Init` CLI variant.
 - `scripts/gif-recording/01-init-demo.tape` (corresponding demo).
 - **`airis ui` subcommand, the `airis claude tab-title` shim, and the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,7 +153,7 @@ pub enum Commands {
         extra_args: Vec<String>,
     },
 
-    /// Show current workspace and guard status
+    /// Show current workspace status
     Status {
         /// Show a concise one-line status (for shell prompts)
         #[arg(long, short = 's')]
@@ -314,7 +314,7 @@ pub struct WorkspaceArgs {
 
 #[derive(Subcommand)]
 pub enum WorkspaceCommands {
-    /// Uninstall airis from the current workspace (removes shims, hooks, and generated files)
+    /// Uninstall airis from the current workspace (removes hooks and generated files)
     Uninstall,
 }
 

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -352,48 +352,6 @@ fn handle_request(request: McpRequest) -> Result<McpResponse> {
                             }
                         }
                     }
-                },
-                {
-                    "name": "guards_install",
-                    "description": "Install airis command shims (airis guards install). With global=true installs global shims in ~/.airis/bin that intercept pnpm/npm/python outside Docker.",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "global": {
-                                "type": "boolean",
-                                "description": "Install global shims in ~/.airis/bin (default: false = project-local)",
-                                "default": false
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "guards_status",
-                    "description": "Show current airis guard shim status (airis guards status).",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "global": {
-                                "type": "boolean",
-                                "description": "Check global shims (~/.airis/bin) instead of project-local",
-                                "default": false
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "guards_uninstall",
-                    "description": "Remove airis guard shims (airis guards uninstall).",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "global": {
-                                "type": "boolean",
-                                "description": "Remove global shims from ~/.airis/bin",
-                                "default": false
-                            }
-                        }
-                    }
                 }
             ]
         })),
@@ -425,9 +383,6 @@ fn handle_request(request: McpRequest) -> Result<McpResponse> {
                 "workspace_lint" => handle_workspace_lint()?,
                 "workspace_typecheck" => handle_workspace_typecheck()?,
                 "workspace_clean" => handle_workspace_clean(arguments)?,
-                "guards_install" => handle_guards_install(arguments)?,
-                "guards_status" => handle_guards_status(arguments)?,
-                "guards_uninstall" => handle_guards_uninstall(arguments)?,
                 _ => json!({
                     "content": [
                         {
@@ -808,33 +763,6 @@ fn handle_workspace_clean(arguments: &Value) -> Result<Value> {
         args.push("--purge".to_string());
     }
     run_airis_subprocess_dyn(args)
-}
-
-fn handle_guards_install(arguments: &Value) -> Result<Value> {
-    let global = arguments["global"].as_bool().unwrap_or(false);
-    if global {
-        run_airis_subprocess(&["guards", "install", "--global"])
-    } else {
-        run_airis_subprocess(&["guards", "install"])
-    }
-}
-
-fn handle_guards_status(arguments: &Value) -> Result<Value> {
-    let global = arguments["global"].as_bool().unwrap_or(false);
-    if global {
-        run_airis_subprocess(&["guards", "status", "--global"])
-    } else {
-        run_airis_subprocess(&["guards", "status"])
-    }
-}
-
-fn handle_guards_uninstall(arguments: &Value) -> Result<Value> {
-    let global = arguments["global"].as_bool().unwrap_or(false);
-    if global {
-        run_airis_subprocess(&["guards", "uninstall", "--global"])
-    } else {
-        run_airis_subprocess(&["guards", "uninstall"])
-    }
 }
 
 fn handle_workspace_validate_all() -> Result<Value> {

--- a/src/commands/migrate/manifest_gen.rs
+++ b/src/commands/migrate/manifest_gen.rs
@@ -149,11 +149,6 @@ pub(super) fn generate_manifest_content(discovery: &DiscoveryResult) -> Result<S
         lines.push("".to_string());
     }
 
-    // Guards section (docker-first defaults)
-    lines.push("[guards]".to_string());
-    lines.push("deny = [\"npm\", \"yarn\", \"pnpm\"]".to_string());
-    lines.push("".to_string());
-
     // Commands section
     lines.push("[commands]".to_string());
     lines.push("install = \"docker compose run --rm node pnpm install\"".to_string());

--- a/src/commands/run/monitoring.rs
+++ b/src/commands/run/monitoring.rs
@@ -50,14 +50,6 @@ pub fn print_health_summary(_manifest: &Manifest) -> Result<()> {
     };
     println!("   {:<12} {}", "Hygiene:".dimmed(), hygiene_status);
 
-    let has_guards = Path::new(".airis/bin").exists();
-    let guard_status = if has_guards {
-        "✔ ACTIVE (command guards installed)".green()
-    } else {
-        "⚠ UNPROTECTED (guards missing)".red().bold()
-    };
-    println!("   {:<12} {}", "Guards:".dimmed(), guard_status);
-
     let sync_status = if Path::new("pnpm-lock.yaml").exists() {
         "✔ LOCKED (via pnpm-lock.yaml)".green()
     } else {
@@ -65,7 +57,7 @@ pub fn print_health_summary(_manifest: &Manifest) -> Result<()> {
     };
     println!("   {:<12} {}", "Sync:".dimmed(), sync_status);
 
-    if has_node_modules || !has_guards {
+    if has_node_modules {
         println!();
         println!(
             "   {} Run {} to heal your workspace.",

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -91,19 +91,12 @@ fn run_short() -> Result<()> {
             }
         }
 
-        // Bypass check
-        let bypass = std::env::var("AIRIS_SKIP_GUARD").is_ok()
-            || std::env::var("AIRIS_BYPASS").is_ok()
-            || std::env::var("AIRIS_HOST").is_ok();
-
         if polluted {
             parts.push(format!(
                 "💀{}({})",
                 name.red().bold(),
                 "POLLUTED".on_red().white().bold()
             ));
-        } else if bypass {
-            parts.push(format!("{}({})", name.yellow(), "BYPASS".bold().yellow()));
         } else {
             parts.push(name.bright_cyan().bold().to_string());
         }

--- a/src/commands/workspace/uninstall.rs
+++ b/src/commands/workspace/uninstall.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 
 use crate::commands::generate::registry::load_generation_registry;
 
-/// Uninstall airis from the current workspace by removing shims, hooks, and generated files.
+/// Uninstall airis from the current workspace by removing hooks and generated files.
 pub fn uninstall() -> Result<()> {
     println!(
         "{}",
@@ -27,7 +27,6 @@ pub fn uninstall() -> Result<()> {
     println!();
     println!("{}", "✅ Workspace uninstalled successfully.".green());
     println!("   Note: Your manifest.toml and .airis/backups remain untouched.");
-    println!("   To remove global shims, run: airis guards uninstall --global");
 
     Ok(())
 }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -480,7 +480,6 @@ impl Manifest {
                 compose: default_compose_file(),
                 service: String::new(),
                 routes: vec![],
-                shim_commands: default_shim_commands(),
             },
             just: None,
             service: IndexMap::new(),

--- a/src/manifest/schema.rs
+++ b/src/manifest/schema.rs
@@ -627,29 +627,10 @@ pub struct DockerSection {
     /// Command routing rules (glob pattern → service/workdir)
     #[serde(default)]
     pub routes: Vec<DockerRoute>,
-    /// Commands to shim (default: pnpm, npm, node, npx, bun, tsx, next, eslint, vitest, etc.)
-    #[serde(default = "default_shim_commands")]
-    pub shim_commands: Vec<String>,
 }
 
 pub(crate) fn default_compose_file() -> String {
     "compose.yml".to_string()
-}
-
-pub(crate) fn default_shim_commands() -> Vec<String> {
-    vec![
-        "pnpm".to_string(),
-        "npm".to_string(),
-        "node".to_string(),
-        "npx".to_string(),
-        "bun".to_string(),
-        "tsx".to_string(),
-        "next".to_string(),
-        "eslint".to_string(),
-        "vitest".to_string(),
-        "tsc".to_string(),
-        "turbo".to_string(),
-    ]
 }
 
 /// Route configuration for Docker command execution


### PR DESCRIPTION
## Summary

The guard/shim subsystem was removed in 472ec2e (2026-05-23), but several dead remnants survived. This PR removes them:

- **MCP server no longer advertises broken `guards_*` tools** (`guards_install`/`guards_status`/`guards_uninstall` subprocess-called the deleted `airis guards` subcommand and failed at runtime) — `src/commands/mcp/mod.rs`
- Unused `shim_commands` manifest field + `default_shim_commands()` removed — `src/manifest/schema.rs`, `src/manifest/mod.rs`. Old manifests containing the key still parse (serde ignores unknown keys; `docs.rs` test fixture keeps a `[guards]` section as a backward-compat regression check)
- `airis new` no longer emits a `[guards]` section — `src/commands/migrate/manifest_gen.rs`
- Dead `.airis/bin` health check, `AIRIS_SKIP_GUARD`/`AIRIS_BYPASS`/`AIRIS_HOST` env checks, and stale shim docstrings removed

## Test plan

- `cargo build` clean
- `cargo test`: 334 passed, 0 failed
- `airis mcp` tools/list no longer includes guards tools