### PR TITLE
docs: ランタイム規約とテンプレートを host-native 既定に更新

### DIFF
--- a/.claude/rules/generated/STACK.md
+++ b/.claude/rules/generated/STACK.md
@@ -22,26 +22,26 @@ cargo clippy -- -D warnings
 
 Unit tests live next to the code under `src/` (`#[cfg(test)] mod tests` blocks). Integration tests live in `tests/cli_test.rs` and exercise the built `airis` binary end-to-end via `assert_cmd`.
 
-`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+Run the `cargo` commands above directly — that is the host-native default for this Rust CLI. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files and does not run tests, so it is no substitute for running the checks above before pushing.
 
 ## Documentation Sync
 
 `docs/ai/*.md` is the source of truth for `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` adapters at the repo root. After editing any shared doc:
 
 ```bash
-airis docs sync           # regenerate all vendor adapter files from docs/ai/*
-airis docs sync --force   # overwrite even when [docs.mode = "warn"]
-airis docs list           # show which adapter files are managed
+airis workspace docs sync           # regenerate all vendor adapter files from docs/ai/*
+airis workspace docs sync --force   # overwrite even when [docs.mode = "warn"]
+airis workspace docs list           # show which adapter files are managed
 ```
 
-Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis docs sync` rewrites it.
+Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis workspace docs sync` rewrites it.
 
 ## Module Boundary
 
 airis is a convention-unification engine; Docker is one module within it, not the whole tool.
 
 - **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
-- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+- **Docker module** (only for containerized repos): `compose.yaml` + volume-hygiene generation inside `gen`. airis writes the compose file but does not run containers for you — execution stays host-native by default (`~/.claude/rules/runtime-workflow.md`). The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (host-native CLI/Edge/Workers, native desktop) use airis without it.
 
 ## Important Paths
 

--- a/.claude/rules/generated/WORKFLOW.md
+++ b/.claude/rules/generated/WORKFLOW.md
@@ -3,21 +3,21 @@
 ## Default Flow
 
 1. **Research**: Read the relevant shared docs and inspect the current repository structure. Airis uses conventions (apps/*, libs/*) to automatically detect projects.
-2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis gen` to sync.
+2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis workspace gen` to sync.
 3. **Dependencies (package.json)**: If you need to add libraries, edit the project's `package.json` directly. Airis preserves your edits.
-4. **Execution**: Always use `airis up` to start the environment. It ensures configuration is synced and dependencies are installed inside Docker.
-5. **Verification**: Run `airis verify` before finishing a task to ensure environment integrity and quality gates.
+4. **Execution (host-native default)**: Build and run with the native toolchain directly — for this Rust CLI that is `cargo build` / `cargo run`. Docker is only for local stateful infra or deploy-parity checks, not for everyday execution. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files; it does not run anything. See `~/.claude/rules/runtime-workflow.md` for the org-wide matrix.
+5. **Verification**: Before finishing, run the native checks directly — `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
 
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
 - **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
-- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
+- **Host-native default**: Build, run, and test with the native toolchain on the host. Use Docker only for local stateful infra (DBs) or deploy-parity verification; GPU/k3s workloads run on the cluster. Per-repo overrides win. SSoT: `~/.claude/rules/runtime-workflow.md`.
 
 ## Operational Notes
 
 These are easy to discover the hard way. Read once, save a debugging session.
 
 - **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
-- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.
-- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
+- **`airis workspace gen` does not run tests.** It only writes `compose.yaml` / `tsconfig.json` / AI-rule files. Run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly before pushing so CI is not the first thing to surface a regression.
+- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis workspace docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.

--- a/.cursor/rules/STACK.md
+++ b/.cursor/rules/STACK.md
@@ -22,26 +22,26 @@ cargo clippy -- -D warnings
 
 Unit tests live next to the code under `src/` (`#[cfg(test)] mod tests` blocks). Integration tests live in `tests/cli_test.rs` and exercise the built `airis` binary end-to-end via `assert_cmd`.
 
-`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+Run the `cargo` commands above directly — that is the host-native default for this Rust CLI. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files and does not run tests, so it is no substitute for running the checks above before pushing.
 
 ## Documentation Sync
 
 `docs/ai/*.md` is the source of truth for `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` adapters at the repo root. After editing any shared doc:
 
 ```bash
-airis docs sync           # regenerate all vendor adapter files from docs/ai/*
-airis docs sync --force   # overwrite even when [docs.mode = "warn"]
-airis docs list           # show which adapter files are managed
+airis workspace docs sync           # regenerate all vendor adapter files from docs/ai/*
+airis workspace docs sync --force   # overwrite even when [docs.mode = "warn"]
+airis workspace docs list           # show which adapter files are managed
 ```
 
-Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis docs sync` rewrites it.
+Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis workspace docs sync` rewrites it.
 
 ## Module Boundary
 
 airis is a convention-unification engine; Docker is one module within it, not the whole tool.
 
 - **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
-- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+- **Docker module** (only for containerized repos): `compose.yaml` + volume-hygiene generation inside `gen`. airis writes the compose file but does not run containers for you — execution stays host-native by default (`~/.claude/rules/runtime-workflow.md`). The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (host-native CLI/Edge/Workers, native desktop) use airis without it.
 
 ## Important Paths
 

--- a/.cursor/rules/WORKFLOW.md
+++ b/.cursor/rules/WORKFLOW.md
@@ -3,21 +3,21 @@
 ## Default Flow
 
 1. **Research**: Read the relevant shared docs and inspect the current repository structure. Airis uses conventions (apps/*, libs/*) to automatically detect projects.
-2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis gen` to sync.
+2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis workspace gen` to sync.
 3. **Dependencies (package.json)**: If you need to add libraries, edit the project's `package.json` directly. Airis preserves your edits.
-4. **Execution**: Always use `airis up` to start the environment. It ensures configuration is synced and dependencies are installed inside Docker.
-5. **Verification**: Run `airis verify` before finishing a task to ensure environment integrity and quality gates.
+4. **Execution (host-native default)**: Build and run with the native toolchain directly — for this Rust CLI that is `cargo build` / `cargo run`. Docker is only for local stateful infra or deploy-parity checks, not for everyday execution. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files; it does not run anything. See `~/.claude/rules/runtime-workflow.md` for the org-wide matrix.
+5. **Verification**: Before finishing, run the native checks directly — `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
 
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
 - **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
-- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
+- **Host-native default**: Build, run, and test with the native toolchain on the host. Use Docker only for local stateful infra (DBs) or deploy-parity verification; GPU/k3s workloads run on the cluster. Per-repo overrides win. SSoT: `~/.claude/rules/runtime-workflow.md`.
 
 ## Operational Notes
 
 These are easy to discover the hard way. Read once, save a debugging session.
 
 - **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
-- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.
-- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
+- **`airis workspace gen` does not run tests.** It only writes `compose.yaml` / `tsconfig.json` / AI-rule files. Run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly before pushing so CI is not the first thing to surface a regression.
+- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis workspace docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,24 +45,24 @@ Airis-workspace is a **polyglot monorepo convention-unification engine**. From a
 ## Default Flow
 
 1. **Research**: Read the relevant shared docs and inspect the current repository structure. Airis uses conventions (apps/*, libs/*) to automatically detect projects.
-2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis gen` to sync.
+2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis workspace gen` to sync.
 3. **Dependencies (package.json)**: If you need to add libraries, edit the project's `package.json` directly. Airis preserves your edits.
-4. **Execution**: Always use `airis up` to start the environment. It ensures configuration is synced and dependencies are installed inside Docker.
-5. **Verification**: Run `airis verify` before finishing a task to ensure environment integrity and quality gates.
+4. **Execution (host-native default)**: Build and run with the native toolchain directly — for this Rust CLI that is `cargo build` / `cargo run`. Docker is only for local stateful infra or deploy-parity checks, not for everyday execution. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files; it does not run anything. See `~/.claude/rules/runtime-workflow.md` for the org-wide matrix.
+5. **Verification**: Before finishing, run the native checks directly — `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
 
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
 - **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
-- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
+- **Host-native default**: Build, run, and test with the native toolchain on the host. Use Docker only for local stateful infra (DBs) or deploy-parity verification; GPU/k3s workloads run on the cluster. Per-repo overrides win. SSoT: `~/.claude/rules/runtime-workflow.md`.
 
 ## Operational Notes
 
 These are easy to discover the hard way. Read once, save a debugging session.
 
 - **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
-- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.
-- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
+- **`airis workspace gen` does not run tests.** It only writes `compose.yaml` / `tsconfig.json` / AI-rule files. Run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly before pushing so CI is not the first thing to surface a regression.
+- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis workspace docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
 
 
 ### Source: docs/ai/REVIEW.md
@@ -109,26 +109,26 @@ cargo clippy -- -D warnings
 
 Unit tests live next to the code under `src/` (`#[cfg(test)] mod tests` blocks). Integration tests live in `tests/cli_test.rs` and exercise the built `airis` binary end-to-end via `assert_cmd`.
 
-`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+Run the `cargo` commands above directly — that is the host-native default for this Rust CLI. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files and does not run tests, so it is no substitute for running the checks above before pushing.
 
 ## Documentation Sync
 
 `docs/ai/*.md` is the source of truth for `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` adapters at the repo root. After editing any shared doc:
 
 ```bash
-airis docs sync           # regenerate all vendor adapter files from docs/ai/*
-airis docs sync --force   # overwrite even when [docs.mode = "warn"]
-airis docs list           # show which adapter files are managed
+airis workspace docs sync           # regenerate all vendor adapter files from docs/ai/*
+airis workspace docs sync --force   # overwrite even when [docs.mode = "warn"]
+airis workspace docs list           # show which adapter files are managed
 ```
 
-Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis docs sync` rewrites it.
+Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis workspace docs sync` rewrites it.
 
 ## Module Boundary
 
 airis is a convention-unification engine; Docker is one module within it, not the whole tool.
 
 - **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
-- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+- **Docker module** (only for containerized repos): `compose.yaml` + volume-hygiene generation inside `gen`. airis writes the compose file but does not run containers for you — execution stays host-native by default (`~/.claude/rules/runtime-workflow.md`). The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (host-native CLI/Edge/Workers, native desktop) use airis without it.
 
 ## Important Paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,24 +45,24 @@ Airis-workspace is a **polyglot monorepo convention-unification engine**. From a
 ## Default Flow
 
 1. **Research**: Read the relevant shared docs and inspect the current repository structure. Airis uses conventions (apps/*, libs/*) to automatically detect projects.
-2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis gen` to sync.
+2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis workspace gen` to sync.
 3. **Dependencies (package.json)**: If you need to add libraries, edit the project's `package.json` directly. Airis preserves your edits.
-4. **Execution**: Always use `airis up` to start the environment. It ensures configuration is synced and dependencies are installed inside Docker.
-5. **Verification**: Run `airis verify` before finishing a task to ensure environment integrity and quality gates.
+4. **Execution (host-native default)**: Build and run with the native toolchain directly — for this Rust CLI that is `cargo build` / `cargo run`. Docker is only for local stateful infra or deploy-parity checks, not for everyday execution. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files; it does not run anything. See `~/.claude/rules/runtime-workflow.md` for the org-wide matrix.
+5. **Verification**: Before finishing, run the native checks directly — `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
 
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
 - **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
-- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
+- **Host-native default**: Build, run, and test with the native toolchain on the host. Use Docker only for local stateful infra (DBs) or deploy-parity verification; GPU/k3s workloads run on the cluster. Per-repo overrides win. SSoT: `~/.claude/rules/runtime-workflow.md`.
 
 ## Operational Notes
 
 These are easy to discover the hard way. Read once, save a debugging session.
 
 - **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
-- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.
-- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
+- **`airis workspace gen` does not run tests.** It only writes `compose.yaml` / `tsconfig.json` / AI-rule files. Run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly before pushing so CI is not the first thing to surface a regression.
+- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis workspace docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
 
 
 ### Source: docs/ai/REVIEW.md
@@ -109,26 +109,26 @@ cargo clippy -- -D warnings
 
 Unit tests live next to the code under `src/` (`#[cfg(test)] mod tests` blocks). Integration tests live in `tests/cli_test.rs` and exercise the built `airis` binary end-to-end via `assert_cmd`.
 
-`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+Run the `cargo` commands above directly — that is the host-native default for this Rust CLI. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files and does not run tests, so it is no substitute for running the checks above before pushing.
 
 ## Documentation Sync
 
 `docs/ai/*.md` is the source of truth for `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` adapters at the repo root. After editing any shared doc:
 
 ```bash
-airis docs sync           # regenerate all vendor adapter files from docs/ai/*
-airis docs sync --force   # overwrite even when [docs.mode = "warn"]
-airis docs list           # show which adapter files are managed
+airis workspace docs sync           # regenerate all vendor adapter files from docs/ai/*
+airis workspace docs sync --force   # overwrite even when [docs.mode = "warn"]
+airis workspace docs list           # show which adapter files are managed
 ```
 
-Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis docs sync` rewrites it.
+Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis workspace docs sync` rewrites it.
 
 ## Module Boundary
 
 airis is a convention-unification engine; Docker is one module within it, not the whole tool.
 
 - **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
-- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+- **Docker module** (only for containerized repos): `compose.yaml` + volume-hygiene generation inside `gen`. airis writes the compose file but does not run containers for you — execution stays host-native by default (`~/.claude/rules/runtime-workflow.md`). The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (host-native CLI/Edge/Workers, native desktop) use airis without it.
 
 ## Important Paths
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,24 +45,24 @@ Airis-workspace is a **polyglot monorepo convention-unification engine**. From a
 ## Default Flow
 
 1. **Research**: Read the relevant shared docs and inspect the current repository structure. Airis uses conventions (apps/*, libs/*) to automatically detect projects.
-2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis gen` to sync.
+2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis workspace gen` to sync.
 3. **Dependencies (package.json)**: If you need to add libraries, edit the project's `package.json` directly. Airis preserves your edits.
-4. **Execution**: Always use `airis up` to start the environment. It ensures configuration is synced and dependencies are installed inside Docker.
-5. **Verification**: Run `airis verify` before finishing a task to ensure environment integrity and quality gates.
+4. **Execution (host-native default)**: Build and run with the native toolchain directly — for this Rust CLI that is `cargo build` / `cargo run`. Docker is only for local stateful infra or deploy-parity checks, not for everyday execution. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files; it does not run anything. See `~/.claude/rules/runtime-workflow.md` for the org-wide matrix.
+5. **Verification**: Before finishing, run the native checks directly — `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
 
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
 - **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
-- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
+- **Host-native default**: Build, run, and test with the native toolchain on the host. Use Docker only for local stateful infra (DBs) or deploy-parity verification; GPU/k3s workloads run on the cluster. Per-repo overrides win. SSoT: `~/.claude/rules/runtime-workflow.md`.
 
 ## Operational Notes
 
 These are easy to discover the hard way. Read once, save a debugging session.
 
 - **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
-- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.
-- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
+- **`airis workspace gen` does not run tests.** It only writes `compose.yaml` / `tsconfig.json` / AI-rule files. Run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly before pushing so CI is not the first thing to surface a regression.
+- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis workspace docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
 
 
 ### Source: docs/ai/REVIEW.md
@@ -109,26 +109,26 @@ cargo clippy -- -D warnings
 
 Unit tests live next to the code under `src/` (`#[cfg(test)] mod tests` blocks). Integration tests live in `tests/cli_test.rs` and exercise the built `airis` binary end-to-end via `assert_cmd`.
 
-`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+Run the `cargo` commands above directly — that is the host-native default for this Rust CLI. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files and does not run tests, so it is no substitute for running the checks above before pushing.
 
 ## Documentation Sync
 
 `docs/ai/*.md` is the source of truth for `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` adapters at the repo root. After editing any shared doc:
 
 ```bash
-airis docs sync           # regenerate all vendor adapter files from docs/ai/*
-airis docs sync --force   # overwrite even when [docs.mode = "warn"]
-airis docs list           # show which adapter files are managed
+airis workspace docs sync           # regenerate all vendor adapter files from docs/ai/*
+airis workspace docs sync --force   # overwrite even when [docs.mode = "warn"]
+airis workspace docs list           # show which adapter files are managed
 ```
 
-Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis docs sync` rewrites it.
+Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis workspace docs sync` rewrites it.
 
 ## Module Boundary
 
 airis is a convention-unification engine; Docker is one module within it, not the whole tool.
 
 - **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
-- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+- **Docker module** (only for containerized repos): `compose.yaml` + volume-hygiene generation inside `gen`. airis writes the compose file but does not run containers for you — execution stays host-native by default (`~/.claude/rules/runtime-workflow.md`). The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (host-native CLI/Edge/Workers, native desktop) use airis without it.
 
 ## Important Paths
 

--- a/docs/ai/STACK.md
+++ b/docs/ai/STACK.md
@@ -22,26 +22,26 @@ cargo clippy -- -D warnings
 
 Unit tests live next to the code under `src/` (`#[cfg(test)] mod tests` blocks). Integration tests live in `tests/cli_test.rs` and exercise the built `airis` binary end-to-end via `assert_cmd`.
 
-`airis verify` is a convenience wrapper, but it **skips `cargo check`/`clippy`/`fmt --check`/`test` when the workspace container is offline** and still prints a green summary. Before pushing, run the `cargo` commands above directly (or `airis up` first) so CI is not the first thing to catch a regression.
+Run the `cargo` commands above directly — that is the host-native default for this Rust CLI. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files and does not run tests, so it is no substitute for running the checks above before pushing.
 
 ## Documentation Sync
 
 `docs/ai/*.md` is the source of truth for `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` adapters at the repo root. After editing any shared doc:
 
 ```bash
-airis docs sync           # regenerate all vendor adapter files from docs/ai/*
-airis docs sync --force   # overwrite even when [docs.mode = "warn"]
-airis docs list           # show which adapter files are managed
+airis workspace docs sync           # regenerate all vendor adapter files from docs/ai/*
+airis workspace docs sync --force   # overwrite even when [docs.mode = "warn"]
+airis workspace docs list           # show which adapter files are managed
 ```
 
-Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis docs sync` rewrites it.
+Never hand-edit the `<!-- BEGIN GENERATED airis gen -->` block in the adapter files — `airis workspace docs sync` rewrites it.
 
 ## Module Boundary
 
 airis is a convention-unification engine; Docker is one module within it, not the whole tool.
 
 - **Convention core** (applies to every repo, polyglot): `gen`, `docs`, `claude`, `new`, `validate`, `doctor`, `bump-version`, `verify`. These keep AI adapters, docs, `tsconfig.json`, version scheme, and scaffolding consistent.
-- **Docker module** (only for containerized repos): `up` / `down` / `exec` / `ps` / `logs` / `restart` / `network` / `run`, plus `compose.yaml` + volume-hygiene generation inside `gen`. The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (Edge/Workers, native desktop) use airis without it.
+- **Docker module** (only for containerized repos): `compose.yaml` + volume-hygiene generation inside `gen`. airis writes the compose file but does not run containers for you — execution stays host-native by default (`~/.claude/rules/runtime-workflow.md`). The `[docker]` manifest section is optional (`#[serde(default)]`), so non-containerized repos (host-native CLI/Edge/Workers, native desktop) use airis without it.
 
 ## Important Paths
 

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -3,21 +3,21 @@
 ## Default Flow
 
 1. **Research**: Read the relevant shared docs and inspect the current repository structure. Airis uses conventions (apps/*, libs/*) to automatically detect projects.
-2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis gen` to sync.
+2. **Infrastructure (manifest.toml)**: If you need to change ports, volumes, or add explicit overrides, modify `manifest.toml`. Run `airis workspace gen` to sync.
 3. **Dependencies (package.json)**: If you need to add libraries, edit the project's `package.json` directly. Airis preserves your edits.
-4. **Execution**: Always use `airis up` to start the environment. It ensures configuration is synced and dependencies are installed inside Docker.
-5. **Verification**: Run `airis verify` before finishing a task to ensure environment integrity and quality gates.
+4. **Execution (host-native default)**: Build and run with the native toolchain directly — for this Rust CLI that is `cargo build` / `cargo run`. Docker is only for local stateful infra or deploy-parity checks, not for everyday execution. `airis workspace gen` only writes `compose.yaml` / `tsconfig.json` / AI-rule files; it does not run anything. See `~/.claude/rules/runtime-workflow.md` for the org-wide matrix.
+5. **Verification**: Before finishing, run the native checks directly — `cargo fmt --check && cargo clippy -- -D warnings && cargo test`.
 
 ## Design Bias
 
 - **Convention over Configuration**: Prefer repository structure over redundant manifest declarations.
 - **Convention Focus**: Treat Airis as a convention-unification engine across repos (AI adapters, docs, tsconfig, scaffolding), not a task runner or package manager.
-- **Hygiene (containerized repos)**: Keep host-side dependencies out and run inside the container. This does not apply to repos where host execution is canonical (Edge/Workers, native desktop apps).
+- **Host-native default**: Build, run, and test with the native toolchain on the host. Use Docker only for local stateful infra (DBs) or deploy-parity verification; GPU/k3s workloads run on the cluster. Per-repo overrides win. SSoT: `~/.claude/rules/runtime-workflow.md`.
 
 ## Operational Notes
 
 These are easy to discover the hard way. Read once, save a debugging session.
 
 - **Direct push to `main` is rejected** by a repository rule. All changes land via pull request — branch off, push the branch, open a PR, and merge from there.
-- **`airis verify` skips runtime checks when the workspace container is offline.** It will report "All quality checks passed" even if `cargo clippy`, `cargo fmt --check`, and `cargo test` were never run. Before pushing, either bring the container up (`airis up`) or run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly so CI does not surface the first real failure.
-- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.
+- **`airis workspace gen` does not run tests.** It only writes `compose.yaml` / `tsconfig.json` / AI-rule files. Run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` directly before pushing so CI is not the first thing to surface a regression.
+- **`docs/ai/*.md` is the source of truth for the AI adapter files.** When you edit `PROJECT_RULES.md`, `WORKFLOW.md`, `REVIEW.md`, or `STACK.md`, run `airis workspace docs sync` to refresh `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in one pass. Never hand-edit the generated block in the adapter files.

--- a/templates/claude/CLAUDE.md
+++ b/templates/claude/CLAUDE.md
@@ -2,11 +2,13 @@
 
 日本語で回答する。コードコメントは英語。
 
-## Docker-First
+## Runtime — host-native default
 
-全てDockerコンテナ内で実行する。ホストでパッケージマネージャやランタイムを直接実行しない。設計・構成・コマンドの詳細は `~/.claude/rules/docker-first.md` を参照。
+開発機(Mac)は **host-native 既定**。ビルド・実行・テストはホストの native toolchain を直接使う(リポの種別に従い `cargo` / `pnpm` / `pytest` 等)。Docker は ①ローカルの stateful infra(DB など) ②デプロイ先との parity 検証 のときだけ。GPU / k3s 常駐ワークロードはクラスタで動かす。判断軸は「このコードが本番で動くランタイムは何か」。詳細と全社マトリクスは `~/.claude/rules/runtime-workflow.md`(SSoT)を参照。
 
-OrbStack 固有の挙動(自動 `*.orb.local` DNS、ローカル image を k8s から registry なしで参照、`/mnt/mac` 共有など)は `~/.claude/rules/orbstack.md` を参照。
+per-repo の override が優先 — 各リポの `CLAUDE.md` / `docs/ai/` の指定がこの既定に勝つ。
+
+Docker を使う場合の OrbStack 固有の挙動(自動 `*.orb.local` DNS、ローカル image を k8s から registry なしで参照、`/mnt/mac` 共有など)は `~/.claude/rules/orbstack.md` を参照。
 
 ## Safety
 
@@ -47,7 +49,7 @@ infra 固有値(サーバー名、IP、Tailscale、ホストパスなど)は **r
 
 - 「実装しました」で終わりにせず、Playwrightまたはブラウザで自分の目で動作確認する
 - ユーザーの元の問題が実際に解決していることを確認してから報告する
-- push前に `airis test` を実行してエラー0を確認する（.husky/pre-push hook でも lint + typecheck は強制される）
+- push前に各リポの native runner で test / lint / typecheck を実行しエラー0を確認する(Rust なら `cargo test` + `cargo clippy`、Node なら `pnpm test` + `pnpm lint` 等)。`airis test` は v4.0.0 で廃止済みで存在しない。pre-push hook がある場合はそれも通す
 - push後は `gh run watch` でCI完了を待ち、失敗したら `gh run view --log-failed` で原因を確認して自分で修正・re-pushする。CIが通るまでタスク完了を報告しない
 - deployワークフローがトリガーされたら `gh run watch` でデプロイ完了を待ち、失敗したら原因を確認して修正する。特にDockerfileの依存不足に注意
 - デプロイ後のヘルスチェックで問題を発見した場合、原因が今回の変更かどうかに関わらず修復すること。「今回の変更とは無関係」を理由にスキップしてはならない。ユーザーにとってはサービスが動いてるか動いてないかだけが重要


### PR DESCRIPTION
## 目的
全社ランタイムルールの更新 (host-native 既定 / SSoT = \`~/.claude/rules/runtime-workflow.md\`) に合わせて、airis CLI 本体リポの AI 規約と**配布テンプレート**を外科的に更新する。テンプレートは生成先の各リポへ伝播するため、stale ルールの撒き散らしを止めるのが最重要。

## 背景 / 確認した事実
- airis は v4.0.0。ディスパッチャ構造で実コマンドは \`airis workspace <cmd>\`。
- **存在しない**: top-level \`airis up/down/test/lint/exec/shell/verify\`、および Docker module の \`up/down/exec/ps/logs/restart/network/run\` (v4.0.0 で削除済)。
- **実在する**: \`airis workspace gen\` / \`airis workspace docs sync\` / \`airis workspace verify\` 等。\`airis workspace gen\` は compose.yaml / tsconfig.json / AI-rule files を生成するだけ ("stays out of your way for everything else") でテストは実行しない。
- 本リポ自体の build/test は native cargo (\`cargo build/test/clippy/fmt\`)。

## 変更
### 配布テンプレート (最重要)
- \`templates/claude/CLAUDE.md\`:
  - \`## Docker-First\`(全部コンテナ内実行・native 直実行禁止) → \`## Runtime — host-native default\` に書き換え。native toolchain 直叩き既定、Docker は ①ローカル stateful infra ②parity 検証のみ、GPU/k3s はクラスタ。SSoT \`~/.claude/rules/runtime-workflow.md\` 参照。per-repo override 優先を明記。
  - \`docker-first.md\` 参照を撤去。
  - 「push前に \`airis test\`」→ 各リポ native runner の test/lint/typecheck に置換 (\`airis test\` は v4.0.0 で廃止と明記)。

### AI 規約の SoT (本リポの CLAUDE.md 生成元)
- \`docs/ai/WORKFLOW.md\` / \`docs/ai/STACK.md\`:
  - \`airis up\` / \`airis verify\` (撤去済みラッパー前提) → host-native cargo 直叩き + 実在する \`airis workspace gen\` / \`airis workspace docs sync\` / \`airis workspace verify\` に置換。
  - Docker module の実在しないサブコマンド列挙を削除。
  - Design Bias の「コンテナ内で実行」→ host-native 既定 + SSoT 参照に修正。

### 再生成物 (手編集なし)
- \`CLAUDE.md\` / \`AGENTS.md\` / \`GEMINI.md\` の生成ブロック、\`.claude/rules/generated/*\`、\`.cursor/rules/*\` は \`airis workspace gen\` で再生成。生成ブロックは一切手編集していない。

## 検証
- \`git grep\` で stale 参照 (\`airis up/verify/test\`, \`Docker-First\`, \`docker-first.md\`, \`inside Docker\`) が runtime 文脈から消えたことを確認 (残るのは adapter 末尾の attribution 1行のみ、これは pre-existing で scope 外)。
- \`airis workspace gen\` 実行で compose.yaml / tsconfig.json / package.json に churn が出ないことを確認 (markdown のみの差分)。
- PR に記載のコマンドは全て現行 airis CLI に**実在するサブコマンドのみ**。